### PR TITLE
Remove '+' from phone number to SFMC

### DIFF
--- a/basket/news/backends/sfmc.py
+++ b/basket/news/backends/sfmc.py
@@ -295,6 +295,10 @@ class SFMC(object):
 
     @time_request
     def send_sms(self, phone_numbers, message_id):
+        if isinstance(phone_numbers, basestring):
+            phone_numbers = [phone_numbers]
+
+        phone_numbers = [pn.lstrip('+') for pn in phone_numbers]
         data = {
             'mobileNumbers': phone_numbers,
             'Subscribe': True,

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -588,7 +588,7 @@ def add_sms_user(send_name, mobile_number, optin, vendor_id=None):
         if not vendor_id:
             return
 
-    sfmc.send_sms([mobile_number], vendor_id)
+    sfmc.send_sms(mobile_number, vendor_id)
     if optin:
         add_sms_user_optin.delay(mobile_number)
 

--- a/basket/news/tests/test_backends_sfmc.py
+++ b/basket/news/tests/test_backends_sfmc.py
@@ -7,6 +7,32 @@ from basket.news.backends.common import NewsletterException
 from basket.news.backends import sfmc
 
 
+@patch('basket.news.backends.sfmc.requests')
+@patch.object(sfmc.sfmc, '_client', Mock())
+class TestSendSMS(TestCase):
+    def test_single_phone_number(self, req_mock):
+        req_mock.post.return_value.status_code = 200
+        sfmc.sfmc.send_sms('+1234567890', 'dude')
+        url = sfmc.sfmc.sms_api_url.format('dude')
+        req_mock.post.assert_called_with(url, json={
+            'mobileNumbers': ['1234567890'],
+            'Subscribe': True,
+            'Resubscribe': True,
+            'keyword': 'FFDROID',
+        }, headers=sfmc.sfmc.auth_header, timeout=10)
+
+    def test_multiple_phone_numbers(self, req_mock):
+        req_mock.post.return_value.status_code = 200
+        sfmc.sfmc.send_sms(['+1234567890', '+9876543210'], 'dude')
+        url = sfmc.sfmc.sms_api_url.format('dude')
+        req_mock.post.assert_called_with(url, json={
+            'mobileNumbers': ['1234567890', '9876543210'],
+            'Subscribe': True,
+            'Resubscribe': True,
+            'keyword': 'FFDROID',
+        }, headers=sfmc.sfmc.auth_header, timeout=10)
+
+
 @patch('basket.news.backends.sfmc.time', Mock(return_value=600))
 @patch.object(sfmc.ETRefreshClient, 'build_soap_client', Mock())
 @patch.object(sfmc.ETRefreshClient, 'load_wsdl', Mock())

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -343,11 +343,11 @@ class AddSMSUserTests(TestCase):
 
     def test_success(self):
         add_sms_user('foo', '8675309', False)
-        self.send_sms.assert_called_with(['8675309'], 'bar')
+        self.send_sms.assert_called_with('8675309', 'bar')
 
     def test_success_with_vendor_id(self):
         add_sms_user('foo', '8675309', False, vendor_id='foo')
-        self.send_sms.assert_called_with(['8675309'], 'foo')
+        self.send_sms.assert_called_with('8675309', 'foo')
         self.get_sms_vendor_id.assert_not_called()
 
     def test_success_with_optin(self):


### PR DESCRIPTION
Turns out they don't properly support E.164 formatted numbers.