### PR TITLE
Bug 1405042: Add user metadata update endpoint

### DIFF
--- a/basket/news/forms.py
+++ b/basket/news/forms.py
@@ -50,8 +50,9 @@ class NewslettersField(forms.MultipleChoiceField):
 
 
 def country_choices():
+    """Upper and Lower case country codes"""
     regions = product_details.get_regions('en-US')
-    return regions.iteritems()
+    return regions.items() + [(code.upper(), name) for code, name in regions.iteritems()]
 
 
 class SubscribeForm(forms.Form):
@@ -64,3 +65,25 @@ class SubscribeForm(forms.Form):
     last_name = forms.CharField(required=False)
     country = forms.ChoiceField(required=False, choices=country_choices)
     lang = forms.CharField(required=False, validators=[RegexValidator(regex=LANG_RE)])
+
+    def clean_country(self):
+        country = self.cleaned_data['country']
+        if country:
+            return country.lower()
+
+        return country
+
+
+class UpdateUserMeta(forms.Form):
+    source_url = forms.CharField(required=False)
+    first_name = forms.CharField(required=False)
+    last_name = forms.CharField(required=False)
+    country = forms.ChoiceField(required=False, choices=country_choices)
+    lang = forms.CharField(required=False, validators=[RegexValidator(regex=LANG_RE)])
+
+    def clean_country(self):
+        country = self.cleaned_data['country']
+        if country:
+            return country.lower()
+
+        return country

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -332,6 +332,12 @@ def update_get_involved(interest_id, lang, name, email, country, email_format,
 
 
 @et_task
+def update_user_meta(token, data):
+    """Update a user's metadata, not newsletters"""
+    sfdc.update({'token': token}, data)
+
+
+@et_task
 def upsert_user(api_call_type, data):
     """
     Update or insert (upsert) a contact record in SFDC

--- a/basket/news/urls.py
+++ b/basket/news/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import url
 from .views import (confirm, custom_unsub_reason, debug_user,
                     fxa_activity, fxa_register, get_involved, list_newsletters, lookup_user,
                     newsletters, send_recovery_message, subscribe, subscribe_sms, sync_route,
-                    unsubscribe, user)
+                    unsubscribe, user, user_meta)
 
 
 def token_url(url_prefix, *args, **kwargs):
@@ -20,6 +20,7 @@ urlpatterns = (
     url('^subscribe_sms/$', subscribe_sms),
     token_url('unsubscribe', unsubscribe),
     token_url('user', user),
+    token_url('user-meta', user_meta),
     token_url('confirm', confirm),
     url('^debug-user/$', debug_user),
     url('^lookup-user/$', lookup_user, name='lookup_user'),


### PR DESCRIPTION
We need a way to update user metadata (e.g. country, lang) while not touching subscription flags or any other data. This is mostly for a new page on bedrock that only updates the user's country, which is to be used by an email campaign asking people to update their country.