### PR TITLE
Add a subscribe URL that always responds with JSON

### DIFF
--- a/basket/news/views.py
+++ b/basket/news/views.py
@@ -334,15 +334,15 @@ def format_form_errors(errors):
 
 @require_POST
 @csrf_exempt
+def subscribe_json(request):
+    request.META['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
+    return subscribe_main(request)
+
+
+@require_POST
+@csrf_exempt
 def subscribe_main(request):
     """Subscription view for use with client side JS"""
-    if not request.is_secure() and not settings.DEBUG:
-        return HttpResponseJSON({
-            'status': 'error',
-            'errors': ['Secure request is required'],
-            'errors_by_field': {NON_FIELD_ERRORS: ['Secure request is required']}
-        }, 403)
-
     form = SubscribeForm(request.POST)
     if form.is_valid():
         data = form.cleaned_data

--- a/basket/urls.py
+++ b/basket/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import include, url
 from django.contrib import admin
 from django.views.generic import RedirectView
 
-from basket.news.views import healthz, subscribe_main
+from basket.news.views import healthz, subscribe_main, subscribe_json
 
 
 home_redirect = '/admin/' if settings.ADMIN_ONLY_MODE else 'https://www.mozilla.org/'
@@ -16,6 +16,7 @@ urlpatterns = [
 if not settings.ADMIN_ONLY_MODE:
     urlpatterns.append(url(r'^news/', include('basket.news.urls')))
     urlpatterns.append(url(r'^subscribe/?$', subscribe_main))
+    urlpatterns.append(url(r'^subscribe\.json$', subscribe_json))
 
 if settings.DISABLE_ADMIN:
     urlpatterns.append(


### PR DESCRIPTION
Sometimes with CORS it can be tough to send the X-Requested-With header. This makes that unnecessary.