### PR TITLE
Should not be an error if donation data is None

### DIFF
--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -840,8 +840,9 @@ def process_donation(data):
     get_lock(data['email'])
     # tells the backend to leave the "subscriber" flag alone
     contact_data = {'_set_subscriber': False}
-    first_name = data.get('first_name', '').strip()
-    last_name = data.get('last_name', '').strip()
+    # do "or ''" because data can contain None values
+    first_name = (data.get('first_name') or '').strip()
+    last_name = (data.get('last_name') or '').strip()
     if first_name and last_name:
         contact_data['first_name'] = first_name
         contact_data['last_name'] = last_name

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -161,6 +161,25 @@ class ProcessDonationTests(TestCase):
             'email': 'dude@example.com',
         })
 
+    def test_name_none(self, sfdc_mock, gud_mock):
+        """Should be okay if only last_name is provided and is None.
+
+        https://sentry.prod.mozaws.net/operations/basket-prod/issues/683973/
+        """
+        data = self.donate_data.copy()
+        gud_mock.return_value = None
+        del data['first_name']
+        data['last_name'] = None
+        with self.assertRaises(RetryTask):
+            # raises retry b/c the 2nd call to get_user_data returns None
+            process_donation(data)
+        sfdc_mock.add.assert_called_with({
+            '_set_subscriber': False,
+            'token': ANY,
+            'record_type': ANY,
+            'email': 'dude@example.com',
+        })
+
     def test_only_update_contact_if_modified(self, sfdc_mock, gud_mock):
         data = self.donate_data.copy()
         gud_mock.return_value = {


### PR DESCRIPTION
first_name and last_name can be defined and "None" in the incoming data. Used to be an AttributeError and now works fine.