### PR TITLE
Add support for `createDate` in the fxa_verified task.

### DIFF
--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-import datetime
+from datetime import datetime, timedelta
 import logging
 from email.utils import formatdate
 from functools import wraps
@@ -31,11 +31,6 @@ from basket.news.newsletters import get_sms_vendor_id, get_transactional_message
 from basket.news.utils import (generate_token, get_accept_languages, get_best_language, get_user_data,
                                iso_format_unix_timestamp, parse_newsletters, parse_newsletters_csv,
                                SUBSCRIBE, UNSUBSCRIBE)
-
-# datetime.datetime is not a submodule, rather datetime is a class
-# within the datetime module.
-# See https://stackoverflow.com/questions/27491472/how-to-directly-import-now-from-datetime-datetime-submodule
-now = datetime.datetime.now
 
 log = logging.getLogger(__name__)
 
@@ -203,8 +198,8 @@ def et_task(func):
 
 def gmttime(basetime=None):
     if basetime is None:
-        basetime = now()
-    d = basetime + datetime.timedelta(minutes=10)
+        basetime = datetime.now()
+    d = basetime + timedelta(minutes=10)
     stamp = mktime(d.timetuple())
     return formatdate(timeval=stamp, localtime=False, usegmt=True)
 
@@ -249,7 +244,7 @@ def fxa_verified(data):
     fxa_id = data['uid']
     create_date = data.get('createDate')
     if create_date:
-        create_date = datetime.datetime.utcfromtimestamp(create_date)
+        create_date = datetime.fromtimestamp(create_date)
 
     locale = data.get('locale')
     subscribe = data.get('marketingOptIn')

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -6,6 +6,8 @@ from django.core.cache import cache
 from django.test import TestCase
 from django.test.utils import override_settings
 
+import datetime
+
 import simple_salesforce as sfapi
 from mock import ANY, Mock, patch
 
@@ -19,6 +21,7 @@ from basket.news.tasks import (
     fxa_email_changed,
     fxa_login,
     fxa_verified,
+    gmttime,
     mogrify_message_id,
     NewsletterException,
     process_donation,
@@ -618,7 +621,7 @@ class FxAVerifiedTests(TestCase):
         }
         fxa_verified(data)
         upsert_mock.delay.assert_not_called()
-        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'])
+        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], None)
 
     def test_with_subscribe(self, upsert_mock, fxa_info_mock):
         data = {
@@ -634,7 +637,7 @@ class FxAVerifiedTests(TestCase):
             'newsletters': settings.FXA_REGISTER_NEWSLETTER,
             'source_url': settings.FXA_REGISTER_SOURCE_URL,
         })
-        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'])
+        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], None)
 
     def test_with_subscribe_and_metrics(self, upsert_mock, fxa_info_mock):
         data = {
@@ -654,7 +657,19 @@ class FxAVerifiedTests(TestCase):
             'newsletters': settings.FXA_REGISTER_NEWSLETTER,
             'source_url': settings.FXA_REGISTER_SOURCE_URL + '?utm_campaign=bowling',
         })
-        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'])
+        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], None)
+
+    def test_with_createDate(self, upsert_mock, fxa_info_mock):
+        create_date_float = 1526996035.498
+        create_date = datetime.datetime.utcfromtimestamp(create_date_float)
+        data = {
+            'createDate': create_date_float,
+            'email': 'thedude@example.com',
+            'uid': 'the-fxa-id',
+            'locale': 'en-US,en'
+        }
+        fxa_verified(data)
+        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], create_date)
 
 
 @patch('basket.news.tasks.upsert_user')
@@ -771,3 +786,18 @@ class FxAEmailChangedTests(TestCase):
             'FXA_ID': data['uid'],
             'NewEmailAddress': data['email'],
         })
+
+
+class GmttimeTests(TestCase):
+    @patch('basket.news.tasks.now')
+    def test_no_basetime_provided(self, now_mock):
+        # original time is 'Fri, 09 Sep 2016 13:33:55 GMT'
+        now_mock.return_value = datetime.datetime.utcfromtimestamp(1473428035.498)
+        formatted_time = gmttime()
+        self.assertEqual(formatted_time, 'Fri, 09 Sep 2016 20:43:55 GMT')
+
+    def test_basetime_provided(self):
+        # original time is 'Fri, 09 Sep 2016 13:33:55 GMT', updates to 13:43:55
+        basetime = datetime.datetime.utcfromtimestamp(1473428035.498)
+        formatted_time = gmttime(basetime)
+        self.assertEqual(formatted_time, 'Fri, 09 Sep 2016 20:43:55 GMT')

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -6,7 +6,7 @@ from django.core.cache import cache
 from django.test import TestCase
 from django.test.utils import override_settings
 
-import datetime
+from datetime import datetime
 
 import simple_salesforce as sfapi
 from mock import ANY, Mock, patch
@@ -661,7 +661,7 @@ class FxAVerifiedTests(TestCase):
 
     def test_with_createDate(self, upsert_mock, fxa_info_mock):
         create_date_float = 1526996035.498
-        create_date = datetime.datetime.utcfromtimestamp(create_date_float)
+        create_date = datetime.fromtimestamp(create_date_float)
         data = {
             'createDate': create_date_float,
             'email': 'thedude@example.com',
@@ -789,15 +789,15 @@ class FxAEmailChangedTests(TestCase):
 
 
 class GmttimeTests(TestCase):
-    @patch('basket.news.tasks.now')
-    def test_no_basetime_provided(self, now_mock):
+    @patch('basket.news.tasks.datetime')
+    def test_no_basetime_provided(self, datetime_mock):
         # original time is 'Fri, 09 Sep 2016 13:33:55 GMT'
-        now_mock.return_value = datetime.datetime.utcfromtimestamp(1473428035.498)
+        datetime_mock.now.return_value = datetime.fromtimestamp(1473428035.498)
         formatted_time = gmttime()
-        self.assertEqual(formatted_time, 'Fri, 09 Sep 2016 20:43:55 GMT')
+        self.assertEqual(formatted_time, 'Fri, 09 Sep 2016 13:43:55 GMT')
 
     def test_basetime_provided(self):
         # original time is 'Fri, 09 Sep 2016 13:33:55 GMT', updates to 13:43:55
-        basetime = datetime.datetime.utcfromtimestamp(1473428035.498)
+        basetime = datetime.fromtimestamp(1473428035.498)
         formatted_time = gmttime(basetime)
-        self.assertEqual(formatted_time, 'Fri, 09 Sep 2016 20:43:55 GMT')
+        self.assertEqual(formatted_time, 'Fri, 09 Sep 2016 13:43:55 GMT')


### PR DESCRIPTION
This is to allow reconciliation with the FxA user DB w/o
sending emails to users that have existed for several years.

cc @pmac 

fixes #76 