### PR TITLE
Add MoFo newsletter subscription option to petition signature task

### DIFF
--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -948,6 +948,14 @@ def process_petition_signature(data):
             # retry here to make sure we associate the donation data with the proper account
             raise RetryTask('User not yet available')
 
+    if data.get('email_subscription', False):
+        upsert_user.delay(SUBSCRIBE, {
+            'token': user_data['token'],
+            'lang': 'en-US',
+            'newsletters': 'mozilla-foundation',
+            'source_url': data['source_url'],
+        })
+
     campaign_member = {
         'CampaignId': data['campaign_id'],
         'ContactId': user_data['id'],


### PR DESCRIPTION
The signature task will now trigger a subscription task if the data
comes in requesting a subscription.