### PR TITLE
Remove unused fxa-register and fxa-activity URLs and Views

### DIFF
--- a/basket/news/management/commands/process_fxa_queue.py
+++ b/basket/news/management/commands/process_fxa_queue.py
@@ -15,25 +15,11 @@ from raven.contrib.django.raven_compat.models import client as sentry_client
 from basket.news.tasks import fxa_delete, fxa_email_changed, fxa_login, fxa_verified
 
 
-# TODO remove this after the cutover
-class FxATSProxyTask(object):
-    """Fake task that will only fire the real task after timestamp"""
-    def __init__(self, task, timestamp):
-        self.task = task
-        self.ts = timestamp
-
-    def delay(self, data):
-        if not self.ts or data['ts'] < self.ts:
-            return
-
-        self.task.delay(data)
-
-
 FXA_EVENT_TYPES = {
     'delete': fxa_delete,
     'verified': fxa_verified,
     'primaryEmailChanged': fxa_email_changed,
-    'login': FxATSProxyTask(fxa_login, settings.FXA_LOGIN_CUTOVER_TIMESTAMP),
+    'login': fxa_login,
 }
 
 

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -56,7 +56,6 @@ IGNORE_ERROR_MSGS_POST_RETRY = [
 ]
 # tasks exempt from maintenance mode queuing
 MAINTENANCE_EXEMPT = [
-    'news.tasks.add_fxa_activity',
     'news.tasks.add_sms_user',
     'news.tasks.add_sms_user_optin',
 ]
@@ -296,12 +295,6 @@ def fxa_login(data):
             'newsletters': newsletter,
             'source_url': fxa_source_url(metrics),
         })
-
-
-@et_task
-def add_fxa_activity(data):
-    # TODO delete after fxa_activity view is decomissioned
-    _add_fxa_activity(data)
 
 
 def _add_fxa_activity(data):

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -325,15 +325,8 @@ def _add_fxa_activity(data):
     })
 
 
-@et_task
-def update_fxa_info(email, lang, fxa_id):
-    # TODO delete after fxa_register view is decomissioned
-    _update_fxa_info(email, lang, fxa_id)
-
-
 def _update_fxa_info(email, lang, fxa_id, create_date=None):
-    # for use with update_fxa_info and fxa_verified
-    # TODO move to fxa_verified after decomission of fxa_register view
+    # leaving here because easier to test
     try:
         apply_updates('Firefox_Account_ID', {
             'EMAIL_ADDRESS_': email,

--- a/basket/news/tests/test__utils.py
+++ b/basket/news/tests/test__utils.py
@@ -6,7 +6,6 @@ import fxa.constants
 import fxa.errors
 from mock import Mock, patch
 
-from basket.news.management.commands.process_fxa_queue import FxATSProxyTask
 from basket.news.models import BlockedEmail
 from basket.news.utils import (
     email_block_list_cache,
@@ -141,52 +140,6 @@ class IsAuthorizedTests(TestCase):
         assert not is_authorized(request, 'dude@example.com')
         hvak_mock.assert_called_with(request)
         hvfo_mock.assert_called_with(request, 'dude@example.com')
-
-
-class FxATSProxyTaskTests(TestCase):
-    def test_no_call_before_timestamp(self):
-        """Should not call task if timestamp is less than desired"""
-        task = Mock()
-        data = {
-            'ts': 1231.123,
-            'dude': 'abiding',
-        }
-        t = FxATSProxyTask(task, 1234)
-        t.delay(data)
-        task.delay.assert_not_called()
-
-    def test_no_call_timestamp_disabled(self):
-        """Should not call task before timestamp is configured"""
-        task = Mock()
-        data = {
-            'ts': 0,
-            'dude': 'abiding',
-        }
-        t = FxATSProxyTask(task, 1234)
-        t.delay(data)
-        task.delay.assert_not_called()
-
-    def test_call_after_timestamp(self):
-        """Should call task after the desired timestamp"""
-        task = Mock()
-        data = {
-            'ts': 1234.123,
-            'dude': 'abiding',
-        }
-        t = FxATSProxyTask(task, 1234)
-        t.delay(data)
-        task.delay.assert_called_with(data)
-
-    def test_call_exatly_at_timestamp(self):
-        """Should call task exactly at the desired timestamp"""
-        task = Mock()
-        data = {
-            'ts': 1234.000,
-            'dude': 'abiding',
-        }
-        t = FxATSProxyTask(task, 1234)
-        t.delay(data)
-        task.delay.assert_called_with(data)
 
 
 class ParsePhoneNumberTests(TestCase):

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -16,7 +16,7 @@ from basket.news.celery import app as celery_app
 from basket.news.models import FailedTask
 from basket.news.newsletters import clear_sms_cache
 from basket.news.tasks import (
-    add_fxa_activity,
+    _add_fxa_activity,
     add_sms_user,
     et_task,
     fxa_email_changed,
@@ -661,7 +661,7 @@ class AddFxaActivityTests(TestCase):
         }
 
         with patch('basket.news.tasks.apply_updates') as apply_updates_mock:
-            add_fxa_activity(data)
+            _add_fxa_activity(data)
         record = apply_updates_mock.call_args[0][1]
         return record
 

--- a/basket/news/urls.py
+++ b/basket/news/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 
 from .views import (confirm, custom_unsub_reason, debug_user,
-                    fxa_activity, fxa_concerts_rsvp, fxa_register, get_involved,
+                    fxa_activity, fxa_concerts_rsvp, get_involved,
                     list_newsletters, lookup_user, newsletters, send_recovery_message,
                     subscribe, subscribe_sms, sync_route, unsubscribe, user, user_meta)
 
@@ -14,7 +14,6 @@ def token_url(url_prefix, *args, **kwargs):
 
 urlpatterns = (
     url('^get-involved/$', get_involved),
-    url('^fxa-register/$', fxa_register),
     url('^fxa-activity/$', fxa_activity),
     url('^fxa-concerts-rsvp/$', fxa_concerts_rsvp),
     url('^subscribe/$', subscribe),

--- a/basket/news/urls.py
+++ b/basket/news/urls.py
@@ -1,7 +1,6 @@
 from django.conf.urls import url
 
-from .views import (confirm, custom_unsub_reason, debug_user,
-                    fxa_activity, fxa_concerts_rsvp, get_involved,
+from .views import (confirm, custom_unsub_reason, debug_user, fxa_concerts_rsvp, get_involved,
                     list_newsletters, lookup_user, newsletters, send_recovery_message,
                     subscribe, subscribe_sms, sync_route, unsubscribe, user, user_meta)
 
@@ -14,7 +13,6 @@ def token_url(url_prefix, *args, **kwargs):
 
 urlpatterns = (
     url('^get-involved/$', get_involved),
-    url('^fxa-activity/$', fxa_activity),
     url('^fxa-concerts-rsvp/$', fxa_concerts_rsvp),
     url('^subscribe/$', subscribe),
     url('^subscribe_sms/$', subscribe_sms),

--- a/basket/news/views.py
+++ b/basket/news/views.py
@@ -27,7 +27,6 @@ from basket.news.tasks import (
     record_fxa_concerts_rsvp,
     send_recovery_message_task,
     update_custom_unsub,
-    update_fxa_info,
     update_get_involved,
     update_user_meta,
     upsert_contact,
@@ -157,60 +156,6 @@ def fxa_activity(request):
         }, 401)
 
     add_fxa_activity.delay(data)
-    return HttpResponseJSON({'status': 'ok'})
-
-
-@require_POST
-@csrf_exempt
-def fxa_register(request):
-    if settings.FXA_EVENTS_QUEUE_ENABLE:
-        # When this setting is true these requests will be handled by
-        # a queue via which we receive various events from FxA. See process_fxa_queue.py.
-        # This is still here to avoid errors during the transition to said queue.
-        # TODO remove after complete transistion to queue
-        return HttpResponseJSON({'status': 'ok'})
-
-    if not has_valid_api_key(request):
-        return HttpResponseJSON({
-            'status': 'error',
-            'desc': 'fxa-register requires a valid API-key',
-            'code': errors.BASKET_AUTH_ERROR,
-        }, 401)
-
-    data = request.POST.dict()
-    if 'email' not in data:
-        return HttpResponseJSON({
-            'status': 'error',
-            'desc': 'fxa-register requires an email address',
-            'code': errors.BASKET_USAGE_ERROR,
-        }, 401)
-
-    email = process_email(data['email'])
-    if not email:
-        return invalid_email_response()
-
-    if 'fxa_id' not in data:
-        return HttpResponseJSON({
-            'status': 'error',
-            'desc': 'fxa-register requires a Firefox Account ID',
-            'code': errors.BASKET_USAGE_ERROR,
-        }, 401)
-    if 'accept_lang' not in data:
-        return HttpResponseJSON({
-            'status': 'error',
-            'desc': 'fxa-register requires accept_lang',
-            'code': errors.BASKET_USAGE_ERROR,
-        }, 401)
-
-    lang = get_best_language(get_accept_languages(data['accept_lang']))
-    if lang is None:
-        return HttpResponseJSON({
-            'status': 'error',
-            'desc': 'invalid language',
-            'code': errors.BASKET_INVALID_LANGUAGE,
-        }, 400)
-
-    update_fxa_info.delay(email, lang, data['fxa_id'])
     return HttpResponseJSON({'status': 'ok'})
 
 

--- a/basket/news/views.py
+++ b/basket/news/views.py
@@ -1,4 +1,3 @@
-import json
 import re
 from time import time
 
@@ -21,7 +20,6 @@ from basket.news.models import Newsletter, Interest, LocaleStewards, NewsletterG
 from basket.news.newsletters import get_sms_vendor_id, newsletter_slugs, newsletter_and_group_slugs, \
     newsletter_private_slugs, get_transactional_message_ids
 from basket.news.tasks import (
-    add_fxa_activity,
     add_sms_user,
     confirm_user,
     record_fxa_concerts_rsvp,
@@ -128,34 +126,6 @@ def confirm(request, token):
                       rate=EMAIL_SUBSCRIBE_RATE_LIMIT, increment=True):
         raise Ratelimited()
     confirm_user.delay(token, start_time=time())
-    return HttpResponseJSON({'status': 'ok'})
-
-
-@require_POST
-@csrf_exempt
-def fxa_activity(request):
-    if not has_valid_api_key(request):
-        return HttpResponseJSON({
-            'status': 'error',
-            'desc': 'fxa-activity requires a valid API-key',
-            'code': errors.BASKET_AUTH_ERROR,
-        }, 401)
-
-    data = json.loads(request.body)
-    if 'fxa_id' not in data:
-        return HttpResponseJSON({
-            'status': 'error',
-            'desc': 'fxa-activity requires a Firefox Account ID',
-            'code': errors.BASKET_USAGE_ERROR,
-        }, 401)
-    if 'user_agent' not in data:
-        return HttpResponseJSON({
-            'status': 'error',
-            'desc': 'fxa-activity requires a device user-agent',
-            'code': errors.BASKET_USAGE_ERROR,
-        }, 401)
-
-    add_fxa_activity.delay(data)
     return HttpResponseJSON({'status': 'ok'})
 
 

--- a/basket/settings.py
+++ b/basket/settings.py
@@ -371,8 +371,6 @@ FXA_OAUTH_SERVER_ENV = config('FXA_OAUTH_SERVER_ENV', default='stable')
 
 FXA_REGISTER_NEWSLETTER = config('FXA_REGISTER_NEWSLETTER', default='firefox-accounts-journey')
 FXA_REGISTER_SOURCE_URL = config('FXA_REGISTER_SOURCE_URL', default='https://accounts.firefox.com/')
-# TODO remove this after the cutover
-FXA_LOGIN_CUTOVER_TIMESTAMP = config('FXA_LOGIN_CUTOVER_TIMESTAMP', default='0', cast=int)
 # TODO move this to the DB
 FXA_LOGIN_CAMPAIGNS = {
     'fxa-embedded-form-moz': 'mozilla-welcome',


### PR DESCRIPTION
The fxa-register data was moved to the queue processing a while back, but the fxa-activity moves tonight. This is cleanup. Only merge after I verify that the queue is working for the fxa-activity (login event) data.