### PR TITLE
Fixed 7 issues of type: PYTHON_E402 throughout 2 files in repo.

### DIFF
--- a/basket/news/celery.py
+++ b/basket/news/celery.py
@@ -1,3 +1,6 @@
+import celery
+from raven.contrib.celery import register_signal, register_logger_signal
+from raven.contrib.django.raven_compat.models import client
 from __future__ import absolute_import
 
 import os
@@ -7,9 +10,6 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'basket.settings')
 
 from django.conf import settings  # noqa
 
-import celery
-from raven.contrib.celery import register_signal, register_logger_signal
-from raven.contrib.django.raven_compat.models import client
 
 
 class Celery(celery.Celery):

--- a/basket/wsgi.py
+++ b/basket/wsgi.py
@@ -1,12 +1,12 @@
+from django.core.handlers.wsgi import WSGIRequest
+from django.core.wsgi import get_wsgi_application
+from raven.contrib.django.raven_compat.middleware.wsgi import Sentry
+from whitenoise.django import DjangoWhiteNoise
 import os
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "basket.settings")
 
-from django.core.handlers.wsgi import WSGIRequest
-from django.core.wsgi import get_wsgi_application
 
-from raven.contrib.django.raven_compat.middleware.wsgi import Sentry
-from whitenoise.django import DjangoWhiteNoise
 
 try:
     import newrelic.agent


### PR DESCRIPTION
PYTHON_E402: 'module level import not at top of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.