### PR TITLE
Add return of FxA holder status with user data requests

### DIFF
--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -272,6 +272,8 @@ def fxa_verified(data):
             'newsletters': settings.FXA_REGISTER_NEWSLETTER,
             'source_url': fxa_source_url(metrics),
         })
+    else:
+        record_source_url(email, fxa_source_url(metrics), 'fxa-no-optin')
 
 
 @et_task

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -798,7 +798,8 @@ class AddFxaActivityTests(TestCase):
 @patch('basket.news.tasks._update_fxa_info')
 @patch('basket.news.tasks.upsert_user')
 class FxAVerifiedTests(TestCase):
-    def test_no_subscribe(self, upsert_mock, fxa_info_mock):
+    @patch('basket.news.tasks.sfmc')
+    def test_no_subscribe(self, sfmc_mock, upsert_mock, fxa_info_mock):
         data = {
             'email': 'thedude@example.com',
             'uid': 'the-fxa-id',
@@ -847,7 +848,8 @@ class FxAVerifiedTests(TestCase):
         })
         fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], 'monitor', None)
 
-    def test_with_createDate(self, upsert_mock, fxa_info_mock):
+    @patch('basket.news.tasks.sfmc')
+    def test_with_createDate(self, sfmc_mock, upsert_mock, fxa_info_mock):
         create_date_float = 1526996035.498
         create_date = datetime.fromtimestamp(create_date_float)
         data = {

--- a/basket/news/views.py
+++ b/basket/news/views.py
@@ -550,7 +550,8 @@ def user(request, token):
             data['email'] = email
         return update_user_task(request, SET, data)
 
-    return get_user(token)
+    get_fxa = 'fxa' in request.GET
+    return get_user(token, get_fxa=get_fxa)
 
 
 @require_POST
@@ -685,6 +686,7 @@ def lookup_user(request):
 
     token = request.GET.get('token', None)
     email = request.GET.get('email', None)
+    get_fxa = 'fxa' in request.GET
 
     if (not email and not token) or (email and token):
         return HttpResponseJSON({
@@ -707,7 +709,7 @@ def lookup_user(request):
             return invalid_email_response()
 
     try:
-        user_data = get_user_data(token=token, email=email)
+        user_data = get_user_data(token=token, email=email, get_fxa=get_fxa)
     except NewsletterException as e:
         return newsletter_exception_response(e)
 


### PR DESCRIPTION
Adding a `?fxa=1` to requests to /news/user/ or /news/lookup-user/ will now return a `has_fxa` parameter. Also record FxA source URL regardless of newsletter optin.

Re #160 #161