### PR TITLE
Accept `newsletters` data with FxA Verified events

### DIFF
--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -248,6 +248,7 @@ def fxa_verified(data):
 
     locale = data.get('locale')
     subscribe = data.get('marketingOptIn')
+    newsletters = data.get('newsletters')
     metrics = data.get('metricsContext', {})
     service = data.get('service', '')
     country = data.get('countryCode', '')
@@ -266,11 +267,20 @@ def fxa_verified(data):
 
     _update_fxa_info(email, lang, fxa_id, service, create_date)
 
-    if subscribe:
+    add_news = None
+    if newsletters:
+        if settings.FXA_REGISTER_NEWSLETTER not in newsletters:
+            newsletters.append(settings.FXA_REGISTER_NEWSLETTER)
+
+        add_news = ','.join(newsletters)
+    elif subscribe:
+        add_news = settings.FXA_REGISTER_NEWSLETTER
+
+    if add_news:
         upsert_user.delay(SUBSCRIBE, {
             'email': email,
             'lang': lang,
-            'newsletters': settings.FXA_REGISTER_NEWSLETTER,
+            'newsletters': add_news,
             'source_url': fxa_source_url(metrics),
             'country': country,
         })

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -787,10 +787,29 @@ class FxAVerifiedTests(TestCase):
             'service': 'sync',
         }
         fxa_verified(data)
-        upsert_mock.delay.assert_called_with(SUBSCRIBE, {
+        upsert_mock.delay.assert_called_once_with(SUBSCRIBE, {
             'email': data['email'],
             'lang': 'en-US',
             'newsletters': settings.FXA_REGISTER_NEWSLETTER,
+            'source_url': settings.FXA_REGISTER_SOURCE_URL,
+            'country': '',
+        })
+        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], 'sync', None)
+
+    def test_with_newsletters(self, upsert_mock, fxa_info_mock):
+        data = {
+            'email': 'thedude@example.com',
+            'uid': 'the-fxa-id',
+            'locale': 'en-US,en',
+            'marketingOptIn': True,
+            'newsletters': ['test-pilot', 'take-action-for-the-internet'],
+            'service': 'sync',
+        }
+        fxa_verified(data)
+        upsert_mock.delay.assert_called_once_with(SUBSCRIBE, {
+            'email': data['email'],
+            'lang': 'en-US',
+            'newsletters': 'test-pilot,take-action-for-the-internet,' + settings.FXA_REGISTER_NEWSLETTER,
             'source_url': settings.FXA_REGISTER_SOURCE_URL,
             'country': '',
         })


### PR DESCRIPTION
Fix #172