### PR TITLE
Remove the old SFMC Double-Opt-In fallback lookup

### DIFF
--- a/basket/news/tests/test_confirm.py
+++ b/basket/news/tests/test_confirm.py
@@ -42,14 +42,3 @@ class TestConfirmTask(TestCase):
         token = "TOKEN"
         confirm_user(token)
         self.assertFalse(sfdc_mock.update.called)
-
-    @patch('basket.news.tasks.get_sfmc_doi_user')
-    def test_user_not_found(self, doi_mock, get_user_data, sfdc_mock):
-        """If we can't find the user, try SFMC"""
-        get_user_data.return_value = None
-        doi_mock.return_value = None
-        token = "TOKEN"
-        confirm_user(token)
-        doi_mock.assert_called_with(token)
-        self.assertFalse(sfdc_mock.add.called)
-        self.assertFalse(sfdc_mock.update.called)


### PR DESCRIPTION
This data extension has been out of use for years at this point.  This method is only slowing things down and adding superfluous requests to SFMC.

Fix #180