### PR TITLE
[fix #166] REST endpoint for Subhub to populate Salesforce

### DIFF
--- a/basket/news/backends/sfdc.py
+++ b/basket/news/backends/sfdc.py
@@ -69,7 +69,7 @@ FIELD_MAP = {
     'cv_first_contribution_date': 'cv_first_contr_dt__c',
     'cv_two_day_streak': 'cv_two_day_streak__c',
     'cv_last_active_date': 'cv_last_active_dt__c',
-    'stripe_id': 'Stripe_Cust_Id__c',
+    'payee_id': 'PMT_Cust_Id__c',
     'fxa_id': 'FxA_Id__c',
 }
 INV_FIELD_MAP = {v: k for k, v in FIELD_MAP.items()}
@@ -310,16 +310,16 @@ class SFDC(object):
         return self._campaign_member
 
     @time_request
-    def get(self, token=None, email=None, stripe_id=None):
+    def get(self, token=None, email=None, payee_id=None):
         """
         Get a contact record.
 
         @param token: external ID
         @param email: email address
-        @param stripe_id: external ID from Stripe
+        @param payee_id: external ID from Stripe/payment processor
         @return: dict
         """
-        assert token or email or stripe_id, 'token, email, or stripe_id is required'
+        assert token or email or payee_id, 'token, email, or payee_id is required'
 
         if token:
             field = 'token'
@@ -328,12 +328,13 @@ class SFDC(object):
             field = 'email'
             value = email
         else:
-            field = 'stripe_id'
-            value = stripe_id
+            field = 'payee_id'
+            value = payee_id
 
         id_field = FIELD_MAP[field]
         contact = self.contact.get_by_custom_id(id_field, value)
         return from_vendor(contact)
+
 
     @time_request
     def add(self, data):

--- a/basket/news/backends/sfdc.py
+++ b/basket/news/backends/sfdc.py
@@ -335,7 +335,6 @@ class SFDC(object):
         contact = self.contact.get_by_custom_id(id_field, value)
         return from_vendor(contact)
 
-
     @time_request
     def add(self, data):
         """

--- a/basket/news/backends/sfdc.py
+++ b/basket/news/backends/sfdc.py
@@ -310,17 +310,29 @@ class SFDC(object):
         return self._campaign_member
 
     @time_request
-    def get(self, token=None, email=None):
+    def get(self, token=None, email=None, stripe_id=None):
         """
         Get a contact record.
 
         @param token: external ID
         @param email: email address
+        @param stripe_id: external ID from Stripe
         @return: dict
         """
-        assert token or email, 'token or email is required'
-        id_field = FIELD_MAP['token' if token else 'email']
-        contact = self.contact.get_by_custom_id(id_field, token or email)
+        assert token or email or stripe_id, 'token, email, or stripe_id is required'
+
+        if token:
+            field = 'token'
+            value = token
+        elif email:
+            field = 'email'
+            value = email
+        else:
+            field = 'stripe_id'
+            value = stripe_id
+
+        id_field = FIELD_MAP[field]
+        contact = self.contact.get_by_custom_id(id_field, value)
         return from_vendor(contact)
 
     @time_request

--- a/basket/news/backends/sfdc.py
+++ b/basket/news/backends/sfdc.py
@@ -69,6 +69,8 @@ FIELD_MAP = {
     'cv_first_contribution_date': 'cv_first_contr_dt__c',
     'cv_two_day_streak': 'cv_two_day_streak__c',
     'cv_last_active_date': 'cv_last_active_dt__c',
+    'stripe_id': 'Stripe_Cust_Id__c',
+    'fxa_id': 'FxA_Id__c',
 }
 INV_FIELD_MAP = {v: k for k, v in FIELD_MAP.items()}
 FIELD_DEFAULTS = {

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -926,10 +926,13 @@ def process_subhub_event_subscription_canceled(data):
 def process_subhub_event_credit_card_expiring(data):
     statsd.incr('news.tasks.process_subhub_event.credit_card_expiring')
 
-    # TODO: need the SFMC extension details from Desi/Marty
-    # sfmc.add_row('Some_Data_Extension_Name', {
-    #    'some': 'data'
-    # })
+    # get the user's email address to send to the extension
+    user_data = get_user_data(payee_id=data['customer_id'])
+
+    if user_data:
+        sfmc.add_row('customer-card-expiring', {
+            'EmailAddress': user_data['email'],
+        })
 
 
 @et_task

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -383,7 +383,8 @@ def upsert_user(api_call_type, data):
     key = data.get('email') or data.get('token')
     get_lock(key)
     upsert_contact(api_call_type, data,
-                   get_user_data(data.get('token'), data.get('email'),
+                   get_user_data(token=data.get('token'),
+                                 email=data.get('email'),
                                  extra_fields=['id']))
 
 
@@ -832,7 +833,7 @@ def process_subhub_event_subscription_charge(data):
         # just in case amount data is missing/malformed
         try:
             # amount values are cents - convert to dollars
-            amount_paid = int(data['amount']) / 100
+            amount_paid = int(data['amount']) / float(100)
         except ValueError:
             amount_paid = 0
 
@@ -876,7 +877,7 @@ def process_subhub_event_subscription_charge(data):
             # determine if this is an initial or recurring payment
             try:
                 # look for existing opportunities with the current subscription_id
-                _ = sfdc.opportunity.get_by_custom_id('PMT_Subscription_ID__C', data['subscription_id'])
+                sfdc.opportunity.get_by_custom_id('PMT_Subscription_ID__C', data['subscription_id'])
             # if no opportunities are found with the current subscription_id,
             # we know this is an initial purchase
             except sfapi.SalesforceResourceNotFound:

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -783,7 +783,6 @@ def process_subhub_event_customer_updated(data):
             sfdc.update(user_data, contact_data)
     # if user wasn't found, add them
     else:
-        # TODO: should we make another statsd call here?
         contact_data['first_name'] = first
         contact_data['last_name'] = last
         contact_data['email'] = data['email']

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -743,8 +743,7 @@ def process_subhub_event_customer_created(data):
         if not user_data['first_name']:
             contact_data['first_name'] = first
 
-        if 'first_name' in contact_data or 'last_name' in contact_data:
-            sfdc.update(user_data, contact_data)
+        sfdc.update(user_data, contact_data)
     # if no user was found, create new user in sfdc
     else:
         contact_data['first_name'] = first
@@ -847,7 +846,7 @@ def process_subhub_event_subscription_charge(data):
             'Amount': amount_paid,
             'currency__c': data['currency'],
             'Name': 'Subscription Services',
-            'RecordTypeId': settings.SUBHUB_OPP_RECORD_TYPE,  # 012R0000000dQ4dIAE for dev
+            'RecordTypeId': settings.SUBHUB_OPP_RECORD_TYPE,
             'StageName': 'Closed Won',
             'Payment_Source__c': 'Stripe',
             'Invoice_Number__c': data['invoice_id'],
@@ -928,14 +927,14 @@ def process_subhub_event_credit_card_expiring(data):
     statsd.incr('news.tasks.process_subhub_event.credit_card_expiring')
 
     # TODO: need the SFMC extension details from Desi/Marty
-    sfmc.add_row('Some_Data_Extension_Name', {
-        'some': 'data'
-    })
+    # sfmc.add_row('Some_Data_Extension_Name', {
+    #    'some': 'data'
+    # })
 
 
 @et_task
 def process_subhub_event_payment_failed(data):
-    statsd.incr('news.tasks.process_subhub_event.subscription_charge')
+    statsd.incr('news.tasks.process_subhub_event.payment_failed')
 
     user_data = get_user_data(payee_id=data['customer_id'])
 

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -273,6 +273,39 @@ class ProcessDonationEventTests(TestCase):
 @override_settings(TASK_LOCKING_ENABLE=False)
 @patch('basket.news.tasks.get_user_data')
 @patch('basket.news.tasks.sfdc')
+class SubHubEventTests(TestCase):
+    def test_customer_created(self, sfdc_mock, gud_mock):
+        pass
+
+    def test_customer_updated_customer_found(self, sfdc_mock, gud_mock):
+        pass
+
+    def test_customer_updated_customer_not_found(self, sfdc_mock, gud_mock):
+        pass
+
+    def test_subscription_charge_finalized(self, sfdc_mock, gud_mock):
+        pass
+
+    def test_subscription_charge_succeeded(self, sfdc_mock, gud_mock):
+        pass
+
+    def test_subscription_canceled(self, sfdc_mock, gud_mock):
+        pass
+
+    def test_subscription_canceled_not_cancelled(self, sfdc_mock, gud_mock):
+        pass
+
+    @patch('basket.news.tasks.sfmc')
+    def test_credit_card_expiring(self, sfdc_mock, gud_mock, sfmc_mock):
+        pass
+
+    def test_payment_failed(self, sfdc_mock, gud_mock):
+        pass
+
+
+@override_settings(TASK_LOCKING_ENABLE=False)
+@patch('basket.news.tasks.get_user_data')
+@patch('basket.news.tasks.sfdc')
 class ProcessDonationTests(TestCase):
     donate_data = {
         'created': 1479746809.327,

--- a/basket/news/utils.py
+++ b/basket/news/utils.py
@@ -280,10 +280,10 @@ IGNORE_USER_FIELDS = [
 ]
 
 
-def get_user_data(token=None, email=None, stripe_id=None, extra_fields=None, get_fxa=False):
+def get_user_data(token=None, email=None, payee_id=None, extra_fields=None, get_fxa=False):
     """Return a dictionary of the user's data from Exact Target.
-    Look them up by their email or stripe customer id if given, otherwise by
-    the token.
+    Look them up by their email or payment processor id (e.g. Stripe) if given,
+    otherwise by the token.
 
     If the user was not found, return None instead of a dictionary.
 
@@ -319,7 +319,7 @@ def get_user_data(token=None, email=None, stripe_id=None, extra_fields=None, get
     }
     """
     try:
-        user = sfdc.get(token, email)
+        user = sfdc.get(token, email, payee_id)
     except sfapi.SalesforceResourceNotFound:
         return None
     except requests.exceptions.RequestException as e:

--- a/basket/news/utils.py
+++ b/basket/news/utils.py
@@ -280,9 +280,10 @@ IGNORE_USER_FIELDS = [
 ]
 
 
-def get_user_data(token=None, email=None, extra_fields=None, get_fxa=False):
+def get_user_data(token=None, email=None, stripe_id=None, extra_fields=None, get_fxa=False):
     """Return a dictionary of the user's data from Exact Target.
-    Look them up by their email if given, otherwise by the token.
+    Look them up by their email or stripe customer id if given, otherwise by
+    the token.
 
     If the user was not found, return None instead of a dictionary.
 

--- a/basket/news/views.py
+++ b/basket/news/views.py
@@ -969,7 +969,7 @@ def subhub_post(request):
 
     try:
         data = json.loads(request.body)
-    except ValueError as _:
+    except ValueError:
         statsd.incr('subhub_post.message.json_error')
         sentry_client.captureException(data={'extra': {'request.body': request.body}})
 
@@ -987,4 +987,7 @@ def subhub_post(request):
             return HttpResponseJSON({'status': 'ok'})
         else:
             # TODO: set a better HTTP response code? 409?
-            return HttpResponseJSON({'status': 'unknown event type'})
+            return HttpResponseJSON({
+                'desc': 'unknown event type',
+                'status': 'error',
+            }, 400)

--- a/basket/news/views.py
+++ b/basket/news/views.py
@@ -40,6 +40,7 @@ from basket.news.tasks import (
     process_subhub_event_customer_created,
     process_subhub_event_customer_updated,
     process_subhub_event_payment_failed,
+    process_subhub_event_subscription_canceled,
     process_subhub_event_subscription_charge,
 )
 from basket.news.utils import (
@@ -79,6 +80,7 @@ sync_route = Route(api_token=settings.SYNC_KEY)
 SUBHUB_EVENT_TYPES = {
     'customer.created': process_subhub_event_customer_created,
     'customer.source.expiring': process_subhub_event_credit_card_expiring,
+    'customer.subscription.updated': process_subhub_event_subscription_canceled,  # cancellations
     'customer.updated': process_subhub_event_customer_updated,
     'invoice.finalized': process_subhub_event_subscription_charge,  # used for both new and recurring charges
     'invoice.payment_failed': process_subhub_event_payment_failed,

--- a/basket/news/views.py
+++ b/basket/news/views.py
@@ -979,7 +979,7 @@ def subhub_post(request):
             'status': 'error',
             'desc': 'JSON error',
             'code': errors.BASKET_USAGE_ERROR,
-        }, 400)  # TODO: find the best status code for this
+        }, 400)
     else:
         etype = data['event_type']
         processor = SUBHUB_EVENT_TYPES.get(etype)
@@ -988,8 +988,8 @@ def subhub_post(request):
             processor.delay(data)
             return HttpResponseJSON({'status': 'ok'})
         else:
-            # TODO: set a better HTTP response code? 409?
             return HttpResponseJSON({
                 'desc': 'unknown event type',
                 'status': 'error',
+                'code': errors.BASKET_USAGE_ERROR
             }, 400)

--- a/basket/settings.py
+++ b/basket/settings.py
@@ -391,6 +391,8 @@ FXA_LOGIN_CAMPAIGNS = {
     'membership-tk': 'member-tk',
 }
 
+SUBHUB_OPP_RECORD_TYPE = config('SUBHUB_OPP_RECORD_TYPE', default='')
+
 COMMON_VOICE_NEWSLETTER = config('COMMON_VOICE_NEWSLETTER', default='common-voice')
 
 OIDC_ENABLE = config('OIDC_ENABLE', default=False, cast=bool)

--- a/basket/urls.py
+++ b/basket/urls.py
@@ -5,7 +5,7 @@ from django.views.generic import RedirectView, TemplateView
 
 from watchman import views as watchman_views
 
-from basket.news.views import subscribe_main, subscribe_json, fxa_start, fxa_callback
+from basket.news.views import subscribe_main, subscribe_json, fxa_start, fxa_callback, subhub_post
 
 
 urlpatterns = [
@@ -21,6 +21,7 @@ if not settings.ADMIN_ONLY_MODE:
     urlpatterns.append(url(r'^subscribe\.json$', subscribe_json))
     urlpatterns.append(url(r'^fxa/?$', fxa_start))
     urlpatterns.append(url(r'^fxa/callback/?$', fxa_callback))
+    urlpatterns.append(url(r'^subhub/?$', subhub_post))
 
 if settings.DISABLE_ADMIN:
     urlpatterns.append(


### PR DESCRIPTION
Create a simple API to capture Stripe transactions and put them in SFDC/SFMC.

All data will come to a single view/endpoint. That view will check the API token, then route the payload to the appropriate task based on the `event_type` sent in the payload. Tasks perform various bits of data transformation and logic before inserting/updating records in Salesforce.

Fixes #166 