### PR TITLE
Fix email missing in common-voice task retries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           name: Run Tests
           command: |
-            bin/dc.sh run --rm --name test-run test-image
+            bin/dc.sh run --name test-run test-image
       - run: docker cp test-run:/app/test-results $TEST_RESULTS
       - store_test_results:
           path: /tmp/test-results

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -672,13 +672,15 @@ def send_recovery_message_task(email):
 
 @et_task
 def record_common_voice_goals(data):
-    email = data.pop('email')
+    # do not change the sent data in place. A retry will use the changed data.
+    dcopy = data.copy()
+    email = dcopy.pop('email')
     user_data = get_user_data(email=email, extra_fields=['id'])
     new_data = {
         'source_url': 'https://voice.mozilla.org',
         'newsletters': [settings.COMMON_VOICE_NEWSLETTER],
     }
-    for k, v in data.items():
+    for k, v in dcopy.items():
         new_data['cv_' + k] = v
 
     if user_data:

--- a/basket/news/views.py
+++ b/basket/news/views.py
@@ -398,13 +398,6 @@ def common_voice_goals(request):
     if form.is_valid():
         # don't send empty values and use ISO formatted date strings
         data = {k: v for k, v in form.cleaned_data.items() if not (v == '' or v is None)}
-        if 'email' not in data:
-            sentry_client.capture('raven.events.Message', request=request)
-            return HttpResponseJSON({
-                'status': 'error',
-                'errors': 'no valid email address'
-            }, 400)
-
         record_common_voice_goals.delay(data)
         return HttpResponseJSON({'status': 'ok'})
     else:


### PR DESCRIPTION
The task was modifying the data dict passed to it (removed the email key). This meant that the data passed to the task on a retry due to a failure of the SFDC call would be missing the email and would fail with a KeyError. This change fixes that and adds tests for the task.