### PR TITLE
Only retry tasks on specific SFDC exceptions

### DIFF
--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -170,8 +170,10 @@ def et_task(func):
 
         try:
             return func(*args, **kwargs)
-        except (IOError, NewsletterException, requests.RequestException,
-                sfapi.SalesforceError, RetryTask) as e:
+        except (IOError, NewsletterException, requests.RequestException, RetryTask,
+                sfapi.SalesforceExpiredSession, sfapi.SalesforceGeneralError,
+                sfapi.SalesforceRefusedRequest, sfapi.SalesforceResourceNotFound,
+                sfapi.SalesforceAuthenticationFailed) as e:
             # These could all be connection issues, so try again later.
             # IOError covers URLError and SSLError.
             if ignore_error(e):

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -481,7 +481,7 @@ class ProcessDonationTests(TestCase):
         }]
         exc = sfapi.SalesforceMalformedRequest('url', 400, 'opportunity', error_content)
         sfdc_mock.opportunity.create.side_effect = exc
-        with self.assertRaises(Retry):
+        with self.assertRaises(sfapi.SalesforceMalformedRequest):
             process_donation(data)
 
 


### PR DESCRIPTION
We used to retry most errors, but this creates a lot more retried tasks for things that can't be recovered which means a lot more API calls than necessary.