### PR TITLE
Record FxA Verified events in SFDC

### DIFF
--- a/basket/news/backends/sfdc.py
+++ b/basket/news/backends/sfdc.py
@@ -77,6 +77,10 @@ FIELD_MAP = {
     'amo_homepage': 'AMO_Homepage_URL__c',
     'payee_id': 'PMT_Cust_Id__c',
     'fxa_id': 'FxA_Id__c',
+    'fxa_deleted': 'FxA_Account_Deleted__c',
+    'fxa_lang': 'FxA_Language__c',
+    'fxa_service': 'FirstService__c',
+    'fxa_create_date': 'FxA_Created_Date__c',
 }
 INV_FIELD_MAP = {v: k for k, v in FIELD_MAP.items()}
 FIELD_DEFAULTS = {

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -958,11 +958,10 @@ class AddFxaActivityTests(TestCase):
         self.assertEqual(record['DEVICE_TYPE'], 'T')
 
 
-@patch('basket.news.tasks._update_fxa_info')
-@patch('basket.news.tasks.upsert_user')
+@patch('basket.news.tasks.get_user_data', return_value=None)
+@patch('basket.news.tasks.upsert_contact')
 class FxAVerifiedTests(TestCase):
-    @patch('basket.news.tasks.sfmc')
-    def test_no_subscribe(self, sfmc_mock, upsert_mock, fxa_info_mock):
+    def test_no_subscribe(self, upsert_mock, gud_mock):
         data = {
             'email': 'thedude@example.com',
             'uid': 'the-fxa-id',
@@ -970,10 +969,16 @@ class FxAVerifiedTests(TestCase):
             'marketingOptIn': False,
         }
         fxa_verified(data)
-        upsert_mock.delay.assert_not_called()
-        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], '', None)
+        upsert_mock.assert_called_once_with(SUBSCRIBE, {
+            'email': data['email'],
+            'source_url': settings.FXA_REGISTER_SOURCE_URL,
+            'country': '',
+            'fxa_lang': 'en-US',
+            'fxa_service': '',
+            'fxa_id': 'the-fxa-id',
+        }, None)
 
-    def test_with_subscribe(self, upsert_mock, fxa_info_mock):
+    def test_with_subscribe(self, upsert_mock, gud_mock):
         data = {
             'email': 'thedude@example.com',
             'uid': 'the-fxa-id',
@@ -982,16 +987,17 @@ class FxAVerifiedTests(TestCase):
             'service': 'sync',
         }
         fxa_verified(data)
-        upsert_mock.delay.assert_called_once_with(SUBSCRIBE, {
+        upsert_mock.assert_called_once_with(SUBSCRIBE, {
             'email': data['email'],
-            'lang': 'en-US',
             'newsletters': settings.FXA_REGISTER_NEWSLETTER,
             'source_url': settings.FXA_REGISTER_SOURCE_URL,
             'country': '',
-        })
-        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], 'sync', None)
+            'fxa_lang': 'en-US',
+            'fxa_service': 'sync',
+            'fxa_id': 'the-fxa-id',
+        }, None)
 
-    def test_with_newsletters(self, upsert_mock, fxa_info_mock):
+    def test_with_newsletters(self, upsert_mock, gud_mock):
         data = {
             'email': 'thedude@example.com',
             'uid': 'the-fxa-id',
@@ -1001,16 +1007,17 @@ class FxAVerifiedTests(TestCase):
             'service': 'sync',
         }
         fxa_verified(data)
-        upsert_mock.delay.assert_called_once_with(SUBSCRIBE, {
+        upsert_mock.assert_called_once_with(SUBSCRIBE, {
             'email': data['email'],
-            'lang': 'en-US',
             'newsletters': 'test-pilot,take-action-for-the-internet,' + settings.FXA_REGISTER_NEWSLETTER,
             'source_url': settings.FXA_REGISTER_SOURCE_URL,
             'country': '',
-        })
-        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], 'sync', None)
+            'fxa_lang': 'en-US',
+            'fxa_service': 'sync',
+            'fxa_id': 'the-fxa-id',
+        }, None)
 
-    def test_with_subscribe_and_metrics(self, upsert_mock, fxa_info_mock):
+    def test_with_subscribe_and_metrics(self, upsert_mock, gud_mock):
         data = {
             'email': 'thedude@example.com',
             'uid': 'the-fxa-id',
@@ -1024,27 +1031,34 @@ class FxAVerifiedTests(TestCase):
             'countryCode': 'DE',
         }
         fxa_verified(data)
-        upsert_mock.delay.assert_called_with(SUBSCRIBE, {
+        upsert_mock.assert_called_with(SUBSCRIBE, {
             'email': data['email'],
-            'lang': 'en-US',
             'newsletters': settings.FXA_REGISTER_NEWSLETTER,
             'source_url': settings.FXA_REGISTER_SOURCE_URL + '?utm_campaign=bowling',
             'country': 'DE',
-        })
-        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], 'monitor', None)
+            'fxa_lang': 'en-US',
+            'fxa_service': 'monitor',
+            'fxa_id': 'the-fxa-id',
+        }, None)
 
-    @patch('basket.news.tasks.sfmc')
-    def test_with_createDate(self, sfmc_mock, upsert_mock, fxa_info_mock):
-        create_date_float = 1526996035.498
-        create_date = datetime.fromtimestamp(create_date_float)
+    def test_with_createDate(self, upsert_mock, gud_mock):
         data = {
-            'createDate': create_date_float,
+            'createDate': 1526996035.498,
             'email': 'thedude@example.com',
             'uid': 'the-fxa-id',
-            'locale': 'en-US,en'
+            'locale': 'en-US,en',
+            'service': 'sync',
         }
         fxa_verified(data)
-        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], '', create_date)
+        upsert_mock.assert_called_with(SUBSCRIBE, {
+            'email': data['email'],
+            'source_url': settings.FXA_REGISTER_SOURCE_URL,
+            'country': '',
+            'fxa_create_date': '2018-05-22T13:33:55.498000',
+            'fxa_id': 'the-fxa-id',
+            'fxa_lang': 'en-US',
+            'fxa_service': 'sync',
+        }, None)
 
 
 @patch('basket.news.tasks.upsert_user')


### PR DESCRIPTION
No longer record the data in SFMC.

Fix #149