### PR TITLE
Remove CircleCI docker layer caching: fix #355

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - run:
           name: Setup
           command: |


### PR DESCRIPTION
This is no longer available in the free plan