### PR TITLE
SubHub: Look up new users by FxA_ID first to avoid dupes

### DIFF
--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -386,12 +386,15 @@ class SubHubEventTests(TestCase):
             'dude@example.com', 'dude@example.com')
 
     def test_customer_created_customer_found(self, sfdc_mock, gud_mock):
+        """
+        Contact found by email only
+        """
         user_data = {
             'first_name': 'Jeffrey',
             'last_name': '_',
         }
 
-        gud_mock.return_value = user_data
+        gud_mock.side_effect = [None, user_data]
 
         process_subhub_event_customer_created({
             'name': 'Jeffrey Lebowski',
@@ -407,7 +410,68 @@ class SubHubEventTests(TestCase):
         })
 
     def test_customer_created_customer_not_found(self, sfdc_mock, gud_mock):
+        """
+        No contact found at all
+        """
         gud_mock.return_value = None
+
+        process_subhub_event_customer_created({
+            'name': 'Walter Sobchak',
+            'email': 'walter@thedude.io',
+            'user_id': '1234',
+            'customer_id': 'cus_1234',
+        })
+
+        sfdc_mock.update.assert_not_called()
+
+        sfdc_mock.add.assert_called_with({
+            'fxa_id': '1234',
+            'payee_id': 'cus_1234',
+            'first_name': 'Walter',
+            'last_name': 'Sobchak',
+            'email': 'walter@thedude.io',
+        })
+
+    def test_customer_created_customer_fxa_found_match(self, sfdc_mock, gud_mock):
+        """
+        Contact found by FxA_ID and email matches
+        """
+        user_data = {
+            'first_name': 'Jeffrey',
+            'last_name': '_',
+            'email': 'walter@thedude.io'
+        }
+        gud_mock.return_value = user_data
+
+        process_subhub_event_customer_created({
+            'name': 'Walter Sobchak',
+            'email': 'walter@thedude.io',
+            'user_id': '1234',
+            'customer_id': 'cus_1234',
+        })
+
+        gud_mock.assert_called_once_with(fxa_id='1234', extra_fields=['id'])
+        sfdc_mock.update.assert_called_once_with(user_data, {
+            'fxa_id': '1234',
+            'payee_id': 'cus_1234',
+            'last_name': 'Sobchak',
+        })
+
+    def test_customer_created_customer_fxa_found_no_match_yes_other(self, sfdc_mock, gud_mock):
+        """
+        Contact found by FxA_ID and email does not match, and other found by email
+        """
+        user_data_fxa = {
+            'first_name': 'Jeffrey',
+            'last_name': '_',
+            'email': 'dude@thedude.io'
+        }
+        user_data = {
+            'first_name': 'Jeffrey',
+            'last_name': '_',
+            'email': 'walter@thedude.io'
+        }
+        gud_mock.side_effect = [user_data_fxa, user_data]
 
         process_subhub_event_customer_created({
             'name': 'Walter Sobchak',
@@ -416,8 +480,40 @@ class SubHubEventTests(TestCase):
             'customer_id': 'cus_1234',
         })
 
-        sfdc_mock.update.assert_not_called()
+        sfdc_mock.update.assert_has_calls([
+            call(user_data_fxa, {
+                'fxa_id': 'DUPE:1234',
+                'fxa_deleted': True,
+            }),
+            call(user_data, {
+                'fxa_id': '1234',
+                'payee_id': 'cus_1234',
+                'last_name': 'Sobchak',
+            })
+        ])
 
+    def test_customer_created_customer_fxa_found_no_match_no_other(self, sfdc_mock, gud_mock):
+        """
+        Contact found by FxA_ID and email does not match, and no other found by email
+        """
+        user_data_fxa = {
+            'first_name': 'Jeffrey',
+            'last_name': '_',
+            'email': 'dude@thedude.io'
+        }
+        gud_mock.side_effect = [user_data_fxa, None]
+
+        process_subhub_event_customer_created({
+            'name': 'Walter Sobchak',
+            'email': 'water@thedude.io',
+            'user_id': '1234',
+            'customer_id': 'cus_1234',
+        })
+
+        sfdc_mock.update.assert_called_once_with(user_data_fxa, {
+            'fxa_id': 'DUPE:1234',
+            'fxa_deleted': True,
+        })
         sfdc_mock.add.assert_called_with({
             'fxa_id': '1234',
             'payee_id': 'cus_1234',


### PR DESCRIPTION
If another contact already has the FxA_ID but a different email address we get errors. This should solve that.

Fix #395