### PR TITLE
Record FxA Verified events in SFDC

### DIFF
--- a/basket/news/backends/sfdc.py
+++ b/basket/news/backends/sfdc.py
@@ -78,6 +78,9 @@ FIELD_MAP = {
     'payee_id': 'PMT_Cust_Id__c',
     'fxa_id': 'FxA_Id__c',
     'fxa_deleted': 'FxA_Account_Deleted__c',
+    'fxa_lang': 'FxA_Language__c',
+    'fxa_service': 'FirstService__c',
+    'fxa_create_date': 'FxA_Created_Date__c',
     'fpn_country': 'FPN_Waitlist_Geo__c',
     'fpn_platform': 'FPN_Waitlist_Platform__c',
 }

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -248,9 +248,6 @@ def fxa_verified(data):
     email = data['email']
     fxa_id = data['uid']
     create_date = data.get('createDate')
-    if create_date:
-        create_date = datetime.fromtimestamp(create_date)
-
     locale = data.get('locale')
     subscribe = data.get('marketingOptIn')
     newsletters = data.get('newsletters')
@@ -270,7 +267,16 @@ def fxa_verified(data):
     if not lang:
         return
 
-    _update_fxa_info(email, lang, fxa_id, service, create_date)
+    user_data = {
+        'email': email,
+        'source_url': fxa_source_url(metrics),
+        'country': country,
+        'fxa_lang': lang,
+        'fxa_service': service,
+        'fxa_id': fxa_id,
+    }
+    if create_date:
+        user_data['fxa_create_date'] = iso_format_unix_timestamp(create_date)
 
     add_news = None
     if newsletters:
@@ -282,15 +288,10 @@ def fxa_verified(data):
         add_news = settings.FXA_REGISTER_NEWSLETTER
 
     if add_news:
-        upsert_user.delay(SUBSCRIBE, {
-            'email': email,
-            'lang': lang,
-            'newsletters': add_news,
-            'source_url': fxa_source_url(metrics),
-            'country': country,
-        })
-    else:
-        record_source_url(email, fxa_source_url(metrics), 'fxa-no-optin')
+        user_data['newsletters'] = add_news
+
+    upsert_contact(SUBSCRIBE, user_data,
+                   get_user_data(email=email, extra_fields=['id']))
 
 
 @et_task
@@ -339,21 +340,6 @@ def _add_fxa_activity(data):
         'DEVICE_NAME': user_agent.device.family,
         'DEVICE_TYPE': device_type,
     })
-
-
-def _update_fxa_info(email, lang, fxa_id, service, create_date=None):
-    # leaving here because easier to test
-    try:
-        apply_updates('Firefox_Account_ID', {
-            'EMAIL_ADDRESS_': email,
-            'CREATED_DATE_': gmttime(create_date),
-            'FXA_ID': fxa_id,
-            'FXA_LANGUAGE_ISO2': lang,
-            'SERVICE': service,
-        })
-    except NewsletterException as e:
-        # don't report these errors to sentry until retries exhausted
-        raise RetryTask(str(e))
 
 
 @et_task
@@ -464,6 +450,10 @@ def upsert_contact(api_call_type, data, user_data):
     if user_data is None:
         # no user found. create new one.
         update_data['token'] = generate_token()
+        if 'fxa_lang' in update_data:
+            # set the main lang if we're creating a new user from FxA data
+            update_data.setdefault('lang', update_data['fxa_lang'])
+
         if settings.MAINTENANCE_MODE:
             sfdc_add_update.delay(update_data)
         else:

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -1186,11 +1186,10 @@ class AddFxaActivityTests(TestCase):
         self.assertEqual(record['DEVICE_TYPE'], 'T')
 
 
-@patch('basket.news.tasks._update_fxa_info')
-@patch('basket.news.tasks.upsert_user')
+@patch('basket.news.tasks.get_user_data', return_value=None)
+@patch('basket.news.tasks.upsert_contact')
 class FxAVerifiedTests(TestCase):
-    @patch('basket.news.tasks.sfmc')
-    def test_no_subscribe(self, sfmc_mock, upsert_mock, fxa_info_mock):
+    def test_no_subscribe(self, upsert_mock, gud_mock):
         data = {
             'email': 'thedude@example.com',
             'uid': 'the-fxa-id',
@@ -1198,10 +1197,16 @@ class FxAVerifiedTests(TestCase):
             'marketingOptIn': False,
         }
         fxa_verified(data)
-        upsert_mock.delay.assert_not_called()
-        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], '', None)
+        upsert_mock.assert_called_once_with(SUBSCRIBE, {
+            'email': data['email'],
+            'source_url': settings.FXA_REGISTER_SOURCE_URL,
+            'country': '',
+            'fxa_lang': 'en-US',
+            'fxa_service': '',
+            'fxa_id': 'the-fxa-id',
+        }, None)
 
-    def test_with_subscribe(self, upsert_mock, fxa_info_mock):
+    def test_with_subscribe(self, upsert_mock, gud_mock):
         data = {
             'email': 'thedude@example.com',
             'uid': 'the-fxa-id',
@@ -1210,16 +1215,17 @@ class FxAVerifiedTests(TestCase):
             'service': 'sync',
         }
         fxa_verified(data)
-        upsert_mock.delay.assert_called_once_with(SUBSCRIBE, {
+        upsert_mock.assert_called_once_with(SUBSCRIBE, {
             'email': data['email'],
-            'lang': 'en-US',
             'newsletters': settings.FXA_REGISTER_NEWSLETTER,
             'source_url': settings.FXA_REGISTER_SOURCE_URL,
             'country': '',
-        })
-        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], 'sync', None)
+            'fxa_lang': 'en-US',
+            'fxa_service': 'sync',
+            'fxa_id': 'the-fxa-id',
+        }, None)
 
-    def test_with_newsletters(self, upsert_mock, fxa_info_mock):
+    def test_with_newsletters(self, upsert_mock, gud_mock):
         data = {
             'email': 'thedude@example.com',
             'uid': 'the-fxa-id',
@@ -1229,16 +1235,17 @@ class FxAVerifiedTests(TestCase):
             'service': 'sync',
         }
         fxa_verified(data)
-        upsert_mock.delay.assert_called_once_with(SUBSCRIBE, {
+        upsert_mock.assert_called_once_with(SUBSCRIBE, {
             'email': data['email'],
-            'lang': 'en-US',
             'newsletters': 'test-pilot,take-action-for-the-internet,' + settings.FXA_REGISTER_NEWSLETTER,
             'source_url': settings.FXA_REGISTER_SOURCE_URL,
             'country': '',
-        })
-        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], 'sync', None)
+            'fxa_lang': 'en-US',
+            'fxa_service': 'sync',
+            'fxa_id': 'the-fxa-id',
+        }, None)
 
-    def test_with_subscribe_and_metrics(self, upsert_mock, fxa_info_mock):
+    def test_with_subscribe_and_metrics(self, upsert_mock, gud_mock):
         data = {
             'email': 'thedude@example.com',
             'uid': 'the-fxa-id',
@@ -1252,27 +1259,34 @@ class FxAVerifiedTests(TestCase):
             'countryCode': 'DE',
         }
         fxa_verified(data)
-        upsert_mock.delay.assert_called_with(SUBSCRIBE, {
+        upsert_mock.assert_called_with(SUBSCRIBE, {
             'email': data['email'],
-            'lang': 'en-US',
             'newsletters': settings.FXA_REGISTER_NEWSLETTER,
             'source_url': settings.FXA_REGISTER_SOURCE_URL + '?utm_campaign=bowling',
             'country': 'DE',
-        })
-        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], 'monitor', None)
+            'fxa_lang': 'en-US',
+            'fxa_service': 'monitor',
+            'fxa_id': 'the-fxa-id',
+        }, None)
 
-    @patch('basket.news.tasks.sfmc')
-    def test_with_createDate(self, sfmc_mock, upsert_mock, fxa_info_mock):
-        create_date_float = 1526996035.498
-        create_date = datetime.fromtimestamp(create_date_float)
+    def test_with_createDate(self, upsert_mock, gud_mock):
         data = {
-            'createDate': create_date_float,
+            'createDate': 1526996035.498,
             'email': 'thedude@example.com',
             'uid': 'the-fxa-id',
-            'locale': 'en-US,en'
+            'locale': 'en-US,en',
+            'service': 'sync',
         }
         fxa_verified(data)
-        fxa_info_mock.assert_called_with(data['email'], 'en-US', data['uid'], '', create_date)
+        upsert_mock.assert_called_with(SUBSCRIBE, {
+            'email': data['email'],
+            'source_url': settings.FXA_REGISTER_SOURCE_URL,
+            'country': '',
+            'fxa_create_date': '2018-05-22T13:33:55.498000',
+            'fxa_id': 'the-fxa-id',
+            'fxa_lang': 'en-US',
+            'fxa_service': 'sync',
+        }, None)
 
 
 @patch('basket.news.tasks.upsert_user')


### PR DESCRIPTION
Along with the existing recording to SFMC.

Fix #149