### PR TITLE
dependabot rollup 2021 01 11

### DIFF
--- a/basket/news/utils.py
+++ b/basket/news/utils.py
@@ -538,7 +538,7 @@ def process_email(email):
     except EmailNotValidError:
         return None
 
-    return info.get("email_ascii", None)
+    return info.ascii_email
 
 
 def parse_newsletters_csv(newsletters):

--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ msgpack-python==0.5.6
 mysqlclient==1.4.6
 newrelic==5.4.1.134
 phonenumbers==8.11.4
-PyFxA==0.7.3
+PyFxA==0.7.7
 python-decouple==3.4
 PyYAML==5.3
 https://github.com/mozmeao/FuelSDK-Python/archive/172815bd74009e36b728b16f774f1aafecb06d03.tar.gz#egg=Salesforce-FuelSDK==1.2.0

--- a/requirements.in
+++ b/requirements.in
@@ -30,7 +30,7 @@ mysqlclient==1.4.6
 newrelic==5.4.1.134
 phonenumbers==8.11.4
 PyFxA==0.7.3
-python-decouple==3.3
+python-decouple==3.4
 PyYAML==5.3
 https://github.com/mozmeao/FuelSDK-Python/archive/172815bd74009e36b728b16f774f1aafecb06d03.tar.gz#egg=Salesforce-FuelSDK==1.2.0
 sentry-sdk==0.17.6

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ mozilla-django-oidc==1.2.3
 msgpack-python==0.5.6
 mysqlclient==1.4.6
 newrelic==5.4.1.134
-phonenumbers==8.11.4
+phonenumbers==8.12.15
 PyFxA==0.7.7
 python-decouple==3.4
 PyYAML==5.3

--- a/requirements.in
+++ b/requirements.in
@@ -33,7 +33,7 @@ PyFxA==0.7.7
 python-decouple==3.4
 PyYAML==5.3
 https://github.com/mozmeao/FuelSDK-Python/archive/172815bd74009e36b728b16f774f1aafecb06d03.tar.gz#egg=Salesforce-FuelSDK==1.2.0
-sentry-sdk==0.17.6
+sentry-sdk==0.19.5
 simple-salesforce==1.10.1
 user-agents==2.1
 whitenoise==5.2.0

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ django-redis==4.11.0
 django-statsd-mozilla==0.4.0
 https://github.com/pmclanahan/django-synctool/archive/5f7cf9bad741e60bd9df32aa90e71425d98e437c.tar.gz#egg=django-synctool==1.1.1
 django-watchman==0.17.0
-email-validator==1.0.5
+email-validator==1.1.2
 gunicorn==20.0.4
 hiredis==1.0.1
 importlib-metadata==1.4.0

--- a/requirements.in
+++ b/requirements.in
@@ -45,6 +45,6 @@ mock==3.0.5
 pbr==5.4.4
 pip-tools==5.3.1
 pep8==1.7.1
-pytest-django==3.8.0
+pytest-django==4.1.0
 pytest-pythonpath==0.7.3
 urlwait==0.4

--- a/requirements.in
+++ b/requirements.in
@@ -23,7 +23,7 @@ gunicorn==20.0.4
 hiredis==1.0.1
 importlib-metadata==1.4.0
 ipaddress==1.0.22
-meinheld==1.0.1
+meinheld==1.0.2
 mozilla-django-oidc==1.2.3
 msgpack-python==0.5.6
 mysqlclient==1.4.6

--- a/requirements.in
+++ b/requirements.in
@@ -21,7 +21,7 @@ django-watchman==0.17.0
 email-validator==1.1.2
 gunicorn==20.0.4
 hiredis==1.0.1
-importlib-metadata==1.4.0
+importlib-metadata==3.4.0
 ipaddress==1.0.22
 meinheld==1.0.2
 mozilla-django-oidc==1.2.3

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ celery==4.4.7
 configparser==4.0.2
 contextlib2==0.6.0.post1
 dj-database-url==0.5.0
-django==2.2.13
+django==2.2.17
 django-allow-cidr==0.3.1
 django-cache-url==3.0.0
 django-cors-headers==3.5.0

--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ django-cors-headers==3.5.0
 django-extensions==2.2.6
 django-jsonfield==1.4.0
 django-mozilla-product-details==0.14.1
-django-picklefield==2.1.1
+django-picklefield==3.0.1
 django-ratelimit==2.0.0
 django-redis==4.11.0
 django-statsd-mozilla==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -390,9 +390,9 @@ pyparsing==2.4.7 \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b \
     # via packaging
-pytest-django==3.8.0 \
-    --hash=sha256:456fa6854d04ee625d6bbb8b38ca2259e7040a6f93333bfe8bc8159b7e987203 \
-    --hash=sha256:489b904f695f9fb880ce591cf5a4979880afb467763b1f180c07574554bdfd26 \
+pytest-django==4.1.0 \
+    --hash=sha256:10e384e6b8912ded92db64c58be8139d9ae23fb8361e5fc139d8e4f8fc601bc2 \
+    --hash=sha256:26f02c16d36fd4c8672390deebe3413678d89f30720c16efb8b2a6bf63b9041f \
     # via -r requirements.in
 pytest-pythonpath==0.7.3 \
     --hash=sha256:63fc546ace7d2c845c1ee289e8f7a6362c2b6bae497d10c716e58e253e801d62 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -300,8 +300,8 @@ mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f \
     # via flake8
-meinheld==1.0.1 \
-    --hash=sha256:447de7189e4dc9c1f425aa1b9c8210aab492fda4d86f73a24059264e7d8b0134 \
+meinheld==1.0.2 \
+    --hash=sha256:008c76937ac2117cc69e032dc69cea9f85fc605de9bac1417f447c41c16a56d6 \
     # via -r requirements.in
 mock==3.0.5 \
     --hash=sha256:83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -150,9 +150,9 @@ django-mozilla-product-details==0.14.1 \
     --hash=sha256:5fa2a8c3f2b9489aeb39b42c3612a43b0be5e778ffab07a5a2cf23b1eced4d64 \
     --hash=sha256:b7428e2dae653c4b0e35fa15363dd26b74dba821bf384c5cd835da0f1566b841 \
     # via -r requirements.in
-django-picklefield==2.1.1 \
-    --hash=sha256:67a5e156343e3b032cac2f65565f0faa81635a99c7da74b0f07a0f5db467b646 \
-    --hash=sha256:e03cb181b7161af38ad6b573af127e4fe9b7cc2c455b42c1ec43eaad525ade0a \
+django-picklefield==3.0.1 \
+    --hash=sha256:15ccba592ca953b9edf9532e64640329cd47b136b7f8f10f2939caa5f9ce4287 \
+    --hash=sha256:3c702a54fde2d322fe5b2f39b8f78d9f655b8f77944ab26f703be6c0ed335a35 \
     # via -r requirements.in
 django-ratelimit==2.0.0 \
     --hash=sha256:40dd23dcdda413d2199bb88b4d9151bf66ea19586b2047ada313ddcf77e2959c \

--- a/requirements.txt
+++ b/requirements.txt
@@ -405,8 +405,9 @@ python-dateutil==2.8.1 \
     --hash=sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c \
     --hash=sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a \
     # via botocore
-python-decouple==3.3 \
-    --hash=sha256:55c546b85b0c47a15a47a4312d451a437f7344a9be3e001660bccd93b637de95 \
+python-decouple==3.4 \
+    --hash=sha256:2e5adb0263a4f963b58d7407c4760a2465d464ee212d733e2a2c179e54c08d8f \
+    --hash=sha256:a8268466e6389a639a20deab9d880faee186eb1eb6a05e54375bdf158d691981 \
     # via -r requirements.in
 pytz==2020.5 \
     --hash=sha256:16962c5fb8db4a8f63a26646d8886e9d769b6c511543557bc84e9569fb9a9cb4 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -186,8 +186,9 @@ docutils==0.15.2 \
     --hash=sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827 \
     --hash=sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99 \
     # via botocore
-email-validator==1.0.5 \
-    --hash=sha256:e3e6ede1765d7c1e580d2050d834b2689361f7da2d50ce74df6a5968fca7cb13 \
+email-validator==1.1.2 \
+    --hash=sha256:094b1d1c60d790649989d38d34f69e1ef07792366277a2cf88684d03495d018f \
+    --hash=sha256:1a13bd6050d1db4475f13e444e169b6fe872434922d38968c67cea9568cce2f0 \
     # via -r requirements.in
 entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -484,9 +484,9 @@ s3transfer==0.3.3 \
 https://github.com/mozmeao/FuelSDK-Python/archive/172815bd74009e36b728b16f774f1aafecb06d03.tar.gz#egg=Salesforce-FuelSDK==1.2.0 \
     --hash=sha256:f1511723f4acdc71fde91e4a2b232946cbf9013804bba27e034932cabd2d7709 \
     # via -r requirements.in
-sentry-sdk==0.17.6 \
-    --hash=sha256:1a086486ff9da15791f294f6e9915eb3747d161ef64dee2d038a4d0b4a369b24 \
-    --hash=sha256:45486deb031cea6bbb25a540d7adb4dd48cd8a1cc31e6a5ce9fb4f792a572e9a \
+sentry-sdk==0.19.5 \
+    --hash=sha256:0a711ec952441c2ec89b8f5d226c33bc697914f46e876b44a4edd3e7864cf4d0 \
+    --hash=sha256:737a094e49a529dd0fdcaafa9e97cf7c3d5eb964bd229821d640bc77f3502b3f \
     # via -r requirements.in
 simple-salesforce==1.10.1 \
     --hash=sha256:20fd66cf40da732b9cdcb2f7160dde7bb298ef0c31702d1fdd767d1fc68cfe1b \

--- a/requirements.txt
+++ b/requirements.txt
@@ -343,9 +343,9 @@ pep8==1.7.1 \
     --hash=sha256:b22cfae5db09833bb9bd7c8463b53e1a9c9b39f12e304a8d0bba729c501827ee \
     --hash=sha256:fe249b52e20498e59e0b5c5256aa52ee99fc295b26ec9eaa85776ffdb9fe6374 \
     # via -r requirements.in
-phonenumbers==8.11.4 \
-    --hash=sha256:685e81ac131fea8dbd71b7769d2ac480c9fe9d5a45838e8546f5de9910670e8e \
-    --hash=sha256:9ca4332425ae4f4d1e7925bbf98ef9446755b59a903ae6a63cf4fb19adcd168b \
+phonenumbers==8.12.15 \
+    --hash=sha256:13d499f7114c4b37c54ee844b188d5e7441951a7da41de5fc1a25ff8fdceef80 \
+    --hash=sha256:b734bfcf33e87ddae72196a40b3d1af35abd0beb263816ae18e1bff612926406 \
     # via -r requirements.in
 pip-tools==5.3.1 \
     --hash=sha256:5672c2b6ca0f1fd803f3b45568c2cf7fadf135b4971e7d665232b2075544c0ef \

--- a/requirements.txt
+++ b/requirements.txt
@@ -375,13 +375,13 @@ pyflakes==2.1.1 \
     --hash=sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0 \
     --hash=sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2 \
     # via flake8
-pyfxa==0.7.3 \
-    --hash=sha256:f47f4285629fa6c033c79adc3fb90926c0818a42cfddb04d32818547362f1627 \
+pyfxa==0.7.7 \
+    --hash=sha256:6c85cd08cf05f7138dee1cf2a8a1d68fd428b7b5ad488917c70a2a763d651cdb \
     # via -r requirements.in
 pyjwt==2.0.0 \
     --hash=sha256:5c2ff2eb27d7e342dfc3cafcc16412781f06db2690fbef81922b0172598f085b \
     --hash=sha256:7a2b271c6dac2fda9e0c33d176c4253faba2c6c6b3a99c7f28a32c3c97522779 \
-    # via salesforce-fuelsdk
+    # via pyfxa, salesforce-fuelsdk
 pyopenssl==20.0.1 \
     --hash=sha256:4c231c759543ba02560fcd2480c48dcec4dae34c9da7d3747c508227e0624b51 \
     --hash=sha256:818ae18e06922c066f777a33f1fca45786d85edfe71cd043de6379337a7f274b \

--- a/requirements.txt
+++ b/requirements.txt
@@ -173,9 +173,9 @@ django-watchman==0.17.0 \
     --hash=sha256:5b847fb742a0fa572864641d2c809dfeecb512cf58b45a2adabc0107e67d001d \
     --hash=sha256:6d2fed545ef3128b25927dfe61da46d7bdc2754dc1e76ba1c96576a168a1a506 \
     # via -r requirements.in
-django==2.2.13 \
-    --hash=sha256:84f370f6acedbe1f3c41e1a02de44ac206efda3355e427139ecb785b5f596d80 \
-    --hash=sha256:e8fe3c2b2212dce6126becab7a693157f1a441a07b62ec994c046c76af5bb66d \
+django==2.2.17 \
+    --hash=sha256:558cb27930defd9a6042133258caf797b2d1dee233959f537e3dc475cb49bd7c \
+    --hash=sha256:cf5370a4d7765a9dd6d42a7b96b53c74f9446cd38209211304b210fe0404b861 \
     # via -r requirements.in, django-allow-cidr, django-cors-headers, django-jsonfield, django-mozilla-product-details, django-picklefield, django-redis, django-synctool, django-watchman, mozilla-django-oidc
 dnspython==2.1.0 \
     --hash=sha256:95d12f6ef0317118d2a1a6fc49aac65ffec7eb8087474158f42f26a639135216 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -272,9 +272,9 @@ idna==2.10 \
     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \
     --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0 \
     # via email-validator, requests
-importlib-metadata==1.4.0 \
-    --hash=sha256:bdd9b7c397c273bcc9a11d6629a38487cd07154fa255a467bf704cd2c258e359 \
-    --hash=sha256:f17c015735e1a88296994c0697ecea7e11db24290941983b08c9feb30921e6d8 \
+importlib-metadata==3.4.0 \
+    --hash=sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771 \
+    --hash=sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d \
     # via -r requirements.in
 iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \


### PR DESCRIPTION
- Bump email-validator from 1.0.5 to 1.1.2 (from PR #612)
- Fix usage of email-validator (from PR #612)
- Bump python-decouple from 3.3 to 3.4 (from PR #613)
- Bump django from 2.2.13 to 2.2.17 (from PR #614)
- Bump meinheld from 1.0.1 to 1.0.2 (from PR #615)
- Bump pyfxa from 0.7.3 to 0.7.7 (from PR #616)
- Bump phonenumbers from 8.11.4 to 8.12.15 (from PR #617)
- Bump sentry-sdk from 0.17.6 to 0.19.5 (from PR #618)
- Bump django-picklefield from 2.1.1 to 3.0.1 (from PR #619)
- Bump pytest-django from 3.8.0 to 4.1.0 (from PR #620)
- Bump importlib-metadata from 1.4.0 to 3.4.0 (from PR #621)
