### PR TITLE
Add initial CTMS API integration: Populate Email_Id__c in SFDC

### DIFF
--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -16,6 +16,90 @@ from basket.news.backends.common import get_timer_decorator
 
 time_request = get_timer_decorator("news.backends.ctms")
 
+# Map CTMS group / name pairs to basket flat format names
+# Missing basket names from SFDC integration:
+#  record_type
+#  postal_code
+#  source_url
+#  fsa_*
+#  cv_*
+#  amo_deleted
+#  payee_id
+#  fxa_last_login
+CTMS_TO_BASKET_NAMES = {
+    "amo": {
+        "add_on_ids": None,
+        "display_name": "amo_display_name",
+        "email_opt_in": None,
+        "language": None,
+        "last_login": "amo_last_login",
+        "location": "amo_location",
+        "profile_url": "amo_homepage",
+        "user": "amo_user",
+        "user_id": "amo_id",
+        "username": None,
+        "create_timestamp": None,
+        "update_timestamp": None,
+    },
+    "email": {
+        "primary_email": "email",
+        "basket_token": "token",
+        "double_opt_in": "optin",
+        "sfdc_id": "id",
+        "first_name": "first_name",
+        "last_name": "last_name",
+        "mailing_country": "country",
+        "email_format": "format",
+        "email_lang": "lang",
+        "has_opted_out_of_email": "optout",
+        "unsubscribe_reason": "reason",
+        "email_id": "email_id",
+        "create_timestamp": "created_date",
+        "update_timestamp": "last_modified_date",
+    },
+    "fxa": {
+        "fxa_id": "fxa_id",
+        "primary_email": "fxa_primary_email",
+        "created_date": "fxa_create_date",
+        "lang": "fxa_lang",
+        "first_service": "fxa_service",
+        "account_deleted": "fxa_deleted",
+    },
+    "mofo": {
+        # Need more information about the future MoFo integrations
+        "mofo_email_id": None,
+        "mofo_contact_id": None,
+        "mofo_relevant": None,
+    },
+    "vpn_waitlist": {"geo": "fpn_country", "platform": "fpn_platform"},
+}
+
+
+def from_vendor(contact):
+    """Convert CTMS nested data to basket key-value format
+
+    @params contact: CTMS data
+    @return: dict in basket format
+    """
+    data = {}
+    for group_name, group in contact.items():
+        basket_group = CTMS_TO_BASKET_NAMES.get(group_name)
+        if basket_group:
+            for ctms_name, basket_name in basket_group.items():
+                if basket_name and ctms_name in group:
+                    data[basket_name] = group[ctms_name]
+        elif group_name == "newsletters":
+            # Import newsletter names
+            # Unimported per-newsletter data: format, language, source, unsub_reason
+            newsletters = []
+            for newsletter in group:
+                if newsletter["subscribed"]:
+                    newsletters.append(newsletter["name"])
+            data["newsletters"] = newsletters
+        else:
+            pass
+    return data
+
 
 class CTMSSession:
     """Add authentication to requests to the CTMS API"""
@@ -228,6 +312,69 @@ class CTMSInterface:
         return self.put_by_email_id(email_id, data)
 
 
+class CTMS:
+    """Basket interface to CTMS"""
+
+    def __init__(self, interface):
+        self.interface = interface
+
+    def get(
+        self,
+        email_id=None,
+        token=None,
+        email=None,
+        sfdc_id=None,
+        fxa_id=None,
+        mofo_email_id=None,
+        amo_id=None,
+    ):
+        """
+        Get a contact record, using the first ID provided.
+
+        @param email_id: CTMS email ID
+        @param token: external ID
+        @param email: email address
+        @param sfdc_id: legacy SFDC ID
+        @param fxa_id: external ID from FxA
+        @param mofo_email_id: external ID from MoFo
+        @param amo_id: external ID from AMO
+        @return: dict, or None if disabled
+        """
+        if not self.interface:
+            return None
+
+        if email_id:
+            contact = self.interface.get_by_email_id(email_id)
+        else:
+            if token:
+                params = {"basket_token": token}
+            elif email:
+                params = {"primary_email": email}
+            elif sfdc_id:
+                params = {"sfdc_id": sfdc_id}
+            elif fxa_id:
+                params = {"fxa_id": fxa_id}
+            elif mofo_email_id:
+                params = {"mofo_email_id": mofo_email_id}
+            elif amo_id:
+                params = {"amo_user_id": amo_id}
+            else:
+                raise RuntimeError("One of the arguments must be set")
+
+            contacts = self.interface.get_by_alternate_id(**params)
+            if not contacts:
+                contact = None
+            elif len(contacts) == 1:
+                contact = contacts[0]
+            else:
+                raise RuntimeError(f"Multiple contacts returned for {params}")
+
+        if contact:
+            return from_vendor(contact)
+        else:
+            return None
+
+
 def ctms_session():
     """Return a CTMSSession configured from Django settings."""
     if settings.CTMS_ENABLED:
@@ -247,3 +394,6 @@ def ctms_interface():
         return CTMSInterface(session)
     else:
         return None
+
+
+ctms = CTMS(ctms_interface())

--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -1,0 +1,122 @@
+"""
+API Client Library for Mozilla's Contact Management System (CTMS)
+https://github.com/mozilla-it/ctms-api/
+"""
+
+from functools import cached_property, partialmethod
+from urllib.parse import urlparse, urlunparse, urljoin
+
+from django.conf import settings
+from django.core.cache import cache
+
+from requests_oauthlib import OAuth2Session
+from oauthlib.oauth2 import BackendApplicationClient
+
+
+class CTMSSession:
+    """Add authentication to requests to the CTMS API"""
+
+    def __init__(
+        self, api_url, client_id, client_secret, token_cache_key="ctms_token",
+    ):
+        """Initialize a CTMSSession
+
+        @param api_url: The base API URL (protocol and domain)
+        @param client_id: The CTMS client_id for OAuth2
+        @param client_secret: The CTMS client_secret for OAuth2
+        @param token_cache_key: The cache key to store access tokens
+        """
+        urlbits = urlparse(api_url)
+        if not urlbits.scheme or not urlbits.netloc:
+            raise ValueError("Invalid api_url")
+        self.api_url = urlunparse((urlbits.scheme, urlbits.netloc, "", "", "", ""))
+
+        if not client_id:
+            raise ValueError("client_id is empty")
+        self.client_id = client_id
+
+        if not client_secret:
+            raise ValueError("client_secret is empty")
+        self.client_secret = client_secret
+
+        if not token_cache_key:
+            raise ValueError("client_secret is empty")
+        self.token_cache_key = token_cache_key
+
+    @property
+    def _token(self):
+        """Get the current OAuth2 token"""
+        return cache.get(self.token_cache_key)
+
+    @_token.setter
+    def _token(self, token):
+        """Set the OAuth2 token"""
+        expires_in = int(token.get("expires_in", 60))
+        timeout = int(expires_in * 0.95)
+        cache.set(self.token_cache_key, token, timeout=timeout)
+
+    @classmethod
+    def check_2xx_response(cls, response):
+        """Raise an error for a non-2xx response"""
+        response.raise_for_status()
+        return response
+
+    @cached_property
+    def _session(self):
+        """Get an authenticated OAuth2 session"""
+        client = BackendApplicationClient(client_id=self.client_id)
+        session = OAuth2Session(client=client, token=self._token)
+        session.register_compliance_hook(
+            "access_token_response", CTMSSession.check_2xx_response
+        )
+        if not session.authorized:
+            session = self._authorize_session(session)
+        return session
+
+    def _authorize_session(self, session):
+        """Fetch a client-crendetials token and add to the session."""
+        self._token = session.fetch_token(
+            token_url=urljoin(self.api_url, "/token"),
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+        )
+        return session
+
+    def request(self, method, path, *args, **kwargs):
+        """
+        Request a CTMS API endpoint, with automatic token refresh.
+
+        CTMS doesn't implement a refresh token endpoint (yet?), so we can't use
+        the OAuth2Session auto-refresh features.
+
+        @param method: the HTTP method, like 'GET'
+        @param path: the path on the server, starting with a slash
+        @param *args: positional args for requests.request
+        @param **kwargs: keyword arge for requests.request. Important ones are
+            params (for querystring parameters) and json (for the JSON-encoded
+            body).
+        @return a requests Response
+        """
+        session = self._session
+        url = urljoin(self.api_url, path)
+        resp = session.request(method, url, *args, **kwargs)
+        if resp.status_code == 401:
+            self._session = self._authorize_session(session)
+            resp = session.request(method, url, *args, **kwargs)
+        return resp
+
+    get = partialmethod(request, "GET")
+    post = partialmethod(request, "POST")
+    put = partialmethod(request, "PUT")
+
+
+def ctms_session():
+    """Return a CTMSSession configured from Django settings."""
+    if settings.CTMS_ENABLED:
+        return CTMSSession(
+            api_url=settings.CTMS_URL,
+            client_id=settings.CTMS_CLIENT_ID,
+            client_secret=settings.CTMS_CLIENT_SECRET,
+        )
+    else:
+        return None

--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -12,6 +12,10 @@ from django.core.cache import cache
 from requests_oauthlib import OAuth2Session
 from oauthlib.oauth2 import BackendApplicationClient
 
+from basket.news.backends.common import get_timer_decorator
+
+time_request = get_timer_decorator("news.backends.ctms")
+
 
 class CTMSSession:
     """Add authentication to requests to the CTMS API"""
@@ -110,6 +114,120 @@ class CTMSSession:
     put = partialmethod(request, "PUT")
 
 
+class CTMSInterface:
+    """Basic Interface to the CTMS API"""
+
+    # Identifiers that uniquely identity a CTMS record
+    unique_ids = [
+        "email_id",
+        "basket_token",
+        "primary_email",
+        "sfdc_id",
+        "fxa_id",
+        "mofo_email_id",
+    ]
+    # Identifiers that can be shared by multiple CTMS records
+    shared_ids = ["mofo_contact_id", "amo_user_id", "fxa_primary_email"]
+    all_ids = unique_ids + shared_ids
+
+    def __init__(self, session):
+        self.session = session
+
+    @time_request
+    def get_by_alternate_id(
+        self,
+        email_id=None,
+        primary_email=None,
+        basket_token=None,
+        sfdc_id=None,
+        fxa_id=None,
+        mofo_email_id=None,
+        mofo_contact_id=None,
+        amo_user_id=None,
+        fxa_primary_email=None,
+    ):
+        """
+        Call GET /ctms to get a list of contacts matching all alternate IDs.
+
+        @param email_id: CTMS email ID
+        @param primary_email: User's primary email
+        @param basket_token: Basket's token
+        @param sfdc_id: Legacy SalesForce.com ID
+        @param fxa_id: Firefox Accounts ID
+        @param mofo_email_id: Mozilla Foundation email ID
+        @param mofo_contact_id: Mozilla Foundation contact ID
+        @param amo_user_id: User ID from addons.mozilla.org
+        @param fxa_primary_email: Primary email in Firefox Accounts
+        @return: list of contact dicts
+        @raises: request.HTTPError, status_code 400, on bad auth credentials
+        @raises: request.HTTPError, status_code 401, on no auth credentials
+        @raises: request.HTTPError, status_code 404, on unknown email_id
+        """
+
+        ids = {}
+        for name, value in locals().items():
+            if name in self.all_ids and value is not None:
+                ids[name] = value
+        if not ids:
+            raise ValueError("At least one ID must be non-null")
+        resp = self.session.get("/ctms", params=ids)
+        resp.raise_for_status()
+        return resp.json()
+
+    @time_request
+    def post_to_create(self, data):
+        """
+        Call POST /ctms to create a contact.
+
+        The email (email.primary_email) is the only required item. If the CTMS
+        email_id is not set (email.email_id), the server will generate one. Any
+        unspecified value will be set to a default.
+
+        @param data: The contact data, as a nested dictionary
+        @return: The created contact data
+        """
+        resp = self.session.post("/ctms", json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+    @time_request
+    def get_by_email_id(self, email_id):
+        """
+        Call GET /ctms/{email_id} to get contact data by CTMS email_id.
+
+        @param email_id: The CTMS email_id of the contact
+        @return: The contact data
+        @raises: request.HTTPError, status_code 400, on bad auth credentials
+        @raises: request.HTTPError, status_code 401, on no auth credentials
+        @raises: request.HTTPError, status_code 404, on unknown email_id
+        """
+        resp = self.session.get(f"/ctms/{email_id}")
+        resp.raise_for_status()
+        return resp.json()
+
+    @time_request
+    def put_by_email_id(self, email_id, data):
+        """
+        Call PUT /ctms/{email_id} to replace a CTMS contact by ID
+
+        @param email_id: The CTMS email_id of the contact
+        @param data: The new or updated contact data
+        @return: The created or replaced contact data
+        """
+        resp = self.session.put(f"/ctms/{email_id}", json=data)
+        resp.raise_for_status()
+        return resp.json()
+
+    def put(self, data):
+        """
+        Call PUT /ctms/{email_id} to replace a CTMS contact, using email_id from data
+
+        @return: The created or replaced contact data
+        """
+        email_id = data["email"]["email_id"]
+        return self.put_by_email_id(email_id, data)
+
+
 def ctms_session():
     """Return a CTMSSession configured from Django settings."""
     if settings.CTMS_ENABLED:
@@ -118,5 +236,14 @@ def ctms_session():
             client_id=settings.CTMS_CLIENT_ID,
             client_secret=settings.CTMS_CLIENT_SECRET,
         )
+    else:
+        return None
+
+
+def ctms_interface():
+    """Return a CTMSInterface configured from Django settings."""
+    session = ctms_session()
+    if session:
+        return CTMSInterface(session)
     else:
         return None

--- a/basket/news/backends/sfdc.py
+++ b/basket/news/backends/sfdc.py
@@ -71,6 +71,7 @@ FIELD_MAP = {
     "id": "Id",
     "record_type": "RecordTypeId",
     "email": "Email",
+    "email_id": "Email_Id__c",
     "first_name": "FirstName",
     "last_name": "LastName",
     "format": "Email_Format__c",

--- a/basket/news/tests/test_ctms.py
+++ b/basket/news/tests/test_ctms.py
@@ -1,0 +1,218 @@
+from unittest.mock import patch, Mock, ANY
+import json
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from requests import Response
+from requests.exceptions import HTTPError
+
+from basket.news.backends.ctms import ctms_session, CTMSSession
+
+
+class CTMSSessionTests(TestCase):
+
+    EXAMPLE_TOKEN = {
+        "access_token": "a.long.base64.string",
+        "token_type": "bearer",
+        "expires_in": 3600,
+        "expires_at": 1617144323.2891595,
+    }
+
+    @patch("basket.news.backends.ctms.cache", spec_set=("get", "set"))
+    @patch("basket.news.backends.ctms.OAuth2Session")
+    def test_get_with_new_auth(self, mock_oauth2_session, mock_cache):
+        """An OAuth2 token is fetched if needed."""
+        mock_session = Mock(
+            spec_set=(
+                "authorized",
+                "fetch_token",
+                "request",
+                "register_compliance_hook",
+            )
+        )
+        mock_session.authorized = False
+        mock_session.fetch_token.return_value = self.EXAMPLE_TOKEN
+        mock_response = Mock(spec_set=("status_code",))
+        mock_response.status_code = 200
+        mock_session.request.return_value = mock_response
+        mock_oauth2_session.return_value = mock_session
+        mock_cache.get.return_value = None
+
+        session = CTMSSession("https://ctms.example.com", "id", "secret")
+        resp = session.get("/ctms", params={"primary_email": "test@example.com"})
+        assert resp == mock_response
+
+        mock_oauth2_session.assert_called_once_with(client=ANY, token=None)
+        mock_session.register_compliance_hook.assert_called_once()
+        mock_cache.get.assert_called_once_with("ctms_token")
+        mock_session.fetch_token.assert_called_once_with(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://ctms.example.com/token",
+        )
+        mock_cache.set.assert_called_once_with(
+            "ctms_token", self.EXAMPLE_TOKEN, timeout=3420
+        )
+        mock_session.request.assert_called_once_with(
+            "GET",
+            "https://ctms.example.com/ctms",
+            params={"primary_email": "test@example.com"},
+        )
+
+    @patch("basket.news.backends.ctms.cache", spec_set=("get",))
+    @patch("basket.news.backends.ctms.OAuth2Session")
+    def test_get_with_existing_auth(self, mock_oauth2_session, mock_cache):
+        """An existing OAuth2 token is reused without calling fetch_token."""
+        mock_session = Mock(
+            spec_set=("authorized", "request", "register_compliance_hook")
+        )
+        mock_session.authorized = True
+        mock_response = Mock(spec_set=("status_code",))
+        mock_response.status_code = 200
+        mock_session.request.return_value = mock_response
+        mock_oauth2_session.return_value = mock_session
+        mock_cache.get.return_value = self.EXAMPLE_TOKEN
+
+        session = CTMSSession("https://ctms.example.com", "id", "secret")
+        resp = session.get("/ctms", params={"primary_email": "test@example.com"})
+        assert resp == mock_response
+
+        mock_oauth2_session.assert_called_once_with(
+            client=ANY, token=self.EXAMPLE_TOKEN
+        )
+        mock_session.register_compliance_hook.assert_called_once()
+        mock_cache.get.assert_called_once_with("ctms_token")
+        mock_session.request.assert_called_once_with(
+            "GET",
+            "https://ctms.example.com/ctms",
+            params={"primary_email": "test@example.com"},
+        )
+
+    @patch("basket.news.backends.ctms.cache", spec_set=("get", "set"))
+    @patch("basket.news.backends.ctms.OAuth2Session")
+    def test_get_with_re_auth(self, mock_oauth2_session, mock_cache):
+        """A new OAuth2 token is fetched on an auth error."""
+        mock_session = Mock(
+            spec_set=(
+                "authorized",
+                "fetch_token",
+                "request",
+                "register_compliance_hook",
+            )
+        )
+        mock_session.authorized = True
+        new_token = {
+            "access_token": "a.different.base64.string",
+            "token_type": "bearer",
+            "expires_in": 7200,
+            "expires_at": 161715000.999,
+        }
+        mock_session.fetch_token.return_value = new_token
+        mock_response_1 = Mock(spec_set=("status_code",))
+        mock_response_1.status_code = 401
+        mock_response_2 = Mock(spec_set=("status_code",))
+        mock_response_2.status_code = 200
+        mock_session.request.side_effect = [mock_response_1, mock_response_2]
+        mock_oauth2_session.return_value = mock_session
+        mock_cache.get.return_value = self.EXAMPLE_TOKEN
+
+        session = CTMSSession("https://ctms.example.com", "id", "secret")
+        resp = session.get("/ctms", params={"primary_email": "test@example.com"})
+        assert resp == mock_response_2
+
+        mock_oauth2_session.assert_called_once_with(
+            client=ANY, token=self.EXAMPLE_TOKEN
+        )
+        mock_session.register_compliance_hook.assert_called_once()
+        mock_cache.get.assert_called_once_with("ctms_token")
+        mock_session.fetch_token.assert_called_once_with(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://ctms.example.com/token",
+        )
+        mock_cache.set.assert_called_once_with("ctms_token", new_token, timeout=6840)
+        mock_session.request.assert_called_with(
+            "GET",
+            "https://ctms.example.com/ctms",
+            params={"primary_email": "test@example.com"},
+        )
+        assert mock_session.request.call_count == 2
+
+    @patch("basket.news.backends.ctms.cache", spec_set=("get",))
+    @patch("basket.news.backends.ctms.OAuth2Session")
+    def test_get_with_failed_auth(self, mock_oauth2_session, mock_cache):
+        """A new OAuth2 token is fetched on an auth error."""
+        mock_session = Mock(
+            spec_set=("authorized", "fetch_token", "register_compliance_hook")
+        )
+        mock_session.authorized = False
+        err_resp = Response()
+        err_resp.status_code = 400
+        err_resp._content = json.dumps({"detail": "Incorrect username or password"})
+        err = HTTPError(response=err_resp)
+        mock_session.fetch_token.side_effect = err
+        mock_oauth2_session.return_value = mock_session
+        mock_cache.get.return_value = None
+
+        session = CTMSSession("https://ctms.example.com", "id", "secret")
+        with self.assertRaises(HTTPError) as context:
+            session.get("/ctms", params={"primary_email": "test@example.com"})
+        assert context.exception == err
+
+        mock_oauth2_session.assert_called_once_with(client=ANY, token=None)
+        mock_session.register_compliance_hook.assert_called_once()
+        mock_cache.get.assert_called_once_with("ctms_token")
+        mock_session.fetch_token.assert_called_once_with(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://ctms.example.com/token",
+        )
+
+    def test_init_bad_parameter(self):
+        """CTMSSession() fails if parameters are bad."""
+
+        params = {
+            "api_url": "http://ctms.example.com",
+            "client_id": "id",
+            "client_secret": "secret",
+        }
+        CTMSSession(**params)  # Doesn't raise
+
+        bad_param_values = {
+            "api_url": ("/ctms", "ctms.example.com", "https://"),
+            "client_id": ("",),
+            "client_secret": ("",),
+            "token_cache_key": ("",),
+        }
+        for key, values in bad_param_values.items():
+            for value in values:
+                bad_params = params.copy()
+                bad_params[key] = value
+                with self.assertRaises(ValueError):
+                    CTMSSession(**bad_params)
+
+    def test_init_long_api_url(self):
+        """CTMSSession() uses protocol and netloc of api_url."""
+
+        session = CTMSSession(
+            "https://ctms.example.com/docs?refresh=1", "client_id", "client_secret"
+        )
+        assert session.api_url == "https://ctms.example.com"
+
+    @override_settings(
+        CTMS_ENABLED=True,
+        CTMS_URL="https://ctms.example.com",
+        CTMS_CLIENT_ID="client_id",
+        CTMS_CLIENT_SECRET="client_secret",
+    )
+    def test_ctms_session_enabled(self):
+        """ctms_session() returns a CTMSSession from Django settings"""
+        session = ctms_session()
+        assert session.api_url == "https://ctms.example.com"
+
+    @override_settings(CTMS_ENABLED=False)
+    def test_ctms_session_disabled(self):
+        """ctms_session() returns None when CTMS_ENABLED=False"""
+        session = ctms_session()
+        assert session is None

--- a/basket/news/tests/test_sfdc.py
+++ b/basket/news/tests/test_sfdc.py
@@ -20,6 +20,7 @@ class VendorConversionTests(TestCase):
         }
         data = {
             "email": "dude@example.com ",
+            "email_id": "a-ctms-uuid",
             "token": "    totally-token-man",
             "format": "H",
             "country": "US   ",
@@ -31,6 +32,7 @@ class VendorConversionTests(TestCase):
         }
         contact = {
             "Email_Format__c": "H",
+            "Email_Id__c": "a-ctms-uuid",
             "FirstName": "The",
             "LastName": "Dude",
             "Subscriber__c": True,
@@ -127,6 +129,7 @@ class VendorConversionTests(TestCase):
         data = {
             "id": "vendor-id",
             "email": "dude@example.com",
+            "email_id": "a-ctms-uuid",
             "token": "totally-token-man",
             "format": "H",
             "country": "us",
@@ -151,6 +154,7 @@ class VendorConversionTests(TestCase):
             "Sub_Bowlin__c": True,
             "Sub_Caucasians__c": True,
             "Sub_Fightin__c": False,
+            "Email_Id__c": "a-ctms-uuid",
         }
         self.assertDictEqual(from_vendor(contact), data)
 

--- a/basket/settings.py
+++ b/basket/settings.py
@@ -245,6 +245,18 @@ ACOUSTIC_TX_SERVER_NUMBER = config("ACOUSTIC_TX_SERVER_NUMBER", None)
 # Send confirmation messages via Acoustic Transact
 SEND_CONFIRM_MESSAGES = config("SEND_CONFIRM_MESSAGES", False, cast=bool)
 
+# Mozilla CTMS
+CTMS_ENV = config("CTMS_ENV", "").lower()
+CTMS_ENABLED = config("CTMS_ENABLED", False, cast=bool)
+if CTMS_ENV == "stage":
+    default_url = "https://ctms.stage.mozilla-ess.mozit.cloud"
+elif CTMS_ENV == "prod":
+    default_url = "https://ctms.prod.mozilla-ess.mozit.cloud"
+else:
+    default_url = ""
+CTMS_URL = config("CTMS_URL", default_url)
+CTMS_CLIENT_ID = config("CTMS_CLIENT_ID", None)
+CTMS_CLIENT_SECRET = config("CTMS_CLIENT_SECRET", None)
 
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r"^/(news/|subscribe)"


### PR DESCRIPTION
Add the initial CTMS API integration, as part of #674.

This change supports this workflow:

* SFDC data is exported to BigQuery (BQ) periodically. Most records have an empty ``Email_Id_c``, the new CTMS ``email_id``.
* BQ adds an ``email_id``, includes this in exports to Acoustic
* CTMS imports from BQ (work in progress)
* Basket fetches from SFDC, and captures ``Email_Id__c`` as ``email_id``. If it is empty, Basket calls CTMS, using a similar interface. If CTMS has a matching record, then Basket uses CTMS's ``email_id``.
* If Basket writes to SFDC to update the record, it populates ``Email_Id__c``, syncing it with BQ.

New settings are used to configure the CTMS backend:
* ``CTMS_ENV`` - 'prod' or 'stage' to select a known ``CTMS_URL``
* ``CTMS_ENABLED`` - True to enable, False to disable CTMS integration
* ``CTMS_URL`` - Select an alternate CTMS API URL
* ``CTMS_CLIENT_ID`` - CTMS Client ID, should start with "id_"
* ``CTMS_CLIENT_SECRET`` - CTMS Client secret, should start with "secret_"

## Manual testing
For local testing, I put my stage credentials in my ``.env`` file, and added some test data, like:

```sh
$ docker-compose run --rm test python manage.py shell
```
```python
from basket.news.backends.ctms import ctms
email = 'test-20210402@example.com'  # you may need to adjust
ctms.interface.post_to_create({'email': {'primary_email': email}})
user_data = ctms.get(email=email)
```

With ``DEBUG=1``, you'll see the CTMS requests flying by. I don't have SFDC credentials to test the full integration.

## Details

``basket.news.backends.ctms`` provides new classes:

* ``CTMSSession`` - Similar to ``requests.session``, with ``session.get``, ``session.post``, etc. It loads an existing token from Redis, and, if there is no token or there is an authentication failure, fetches a token using ``CTMS_CLIENT_ID`` and ``CTMS_CLIENT_SECRET``. There are tests, but with so much mocking that I've considered removing them.
* ``CTMSInferface`` - Provides a method for each of the CTMS API endpoints. Only ``get_by_alternate_id`` and ``get_by_email_id`` are used in current code.
* ``CTMS`` - Provides ``get``, closely modelled on ``SFDC.get``, to load data by the best provided ID and convert it to the flat basket format. It takes a ``CTMSInterface`` to do the work, or ``None`` to silently do nothing.

New functions:

* ``from_vendor``: Converts CTMS nested dictionaries to a Basket dictionary, similar to ``SFDC.from_vendor``
* ``ctms_session``: Creates a ``CTMSSession`` from Django settings
* ``ctms_interface``: Same, for ``CTMSInterface``

New object:
* ``ctms``: An instance of ``CTMS`` with a ``CTMSInterface`` and ``CTMSSession`` based on Django settings, similar to ``sfdc.sfdc``. If CTMS is disabled, ``ctms.interface`` will be ``None``, and ``ctms.get()`` will always return ``None``.

# Tasks
*  ~Add [request-oauthlib](https://requests-oauthlib.readthedocs.io/en/latest/) package~ - Included by pysilverpop
* [x] Add Django settings
* [x] Add low-level interface for authenticated requests
* [x] Add endpoint-specific methods ( ``GET /ctms``, ``GET /ctms/{email_id}``, etc.)
* [x] Read and write SFDC's ``Email_Id__c`` as ``email_id``
* [x] Add ``CTMS.get`` that works in a similar way to ``SFDC.get``, converting to the basket dictionary format
* [x] In ``get_user_data``, call ``CTMS.get`` to populate ``email_id`` when unset in SFDC
* ~Integrate with newsletter subscriptions (send subscriptions to CTMS, CTMS email_id to Salesforce)~ save for future PR
* ~Integrate with preference center (send subscriptions to CTMS, CTMS email_id to Salesforce)~ save for future PR
* [x] Prep for review
