### PR TITLE
Add CTMS parallel writes

### DIFF
--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -194,6 +194,7 @@ class CTMSSession:
         return resp
 
     get = partialmethod(request, "GET")
+    patch = partialmethod(request, "PATCH")
     post = partialmethod(request, "POST")
     put = partialmethod(request, "PUT")
 
@@ -310,6 +311,31 @@ class CTMSInterface:
         """
         email_id = data["email"]["email_id"]
         return self.put_by_email_id(email_id, data)
+
+    @time_request
+    def patch_by_email_id(self, email_id, data):
+        """
+        Call PATCH /ctms/{email_id} to partially update a CTMS contact by ID
+
+        To update a data element, send the key and the new value:
+
+          {"email": {"primary_email": "new_email.example.com"}}
+
+        To delete a subgroup, resetting to defaults, send the group value as "DELETE":
+
+          {"amo": DELETE}
+
+        To unsubscribe from all newsletters, set to "UNSUBSCRIBE":
+
+          {"newsletters": "UNSUBSCRIBE"}
+
+        @param email_id: The CTMS email_id of the contact
+        @param data: The contact data to update
+        @return: The updated contact data
+        """
+        resp = self.session.patch(f"/ctms/{email_id}", json=data)
+        resp.raise_for_status()
+        return resp.json()
 
 
 class CTMS:

--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -545,6 +545,32 @@ class CTMS:
         else:
             return None
 
+    def add(self, data):
+        """
+        Create a contact record.
+
+        @param data: user data to add as a new contact.
+        @return: new user data
+        """
+        if not self.interface:
+            return None
+        return self.interface.post_to_create(to_vendor(data))
+
+    def update(self, existing_data, update_data):
+        """
+        Update data in an existing contact record
+
+        @param record: current contact record
+        @param data: dict of user data
+        @return: updated user data
+        """
+        if not self.interface:
+            return None
+        email_id = existing_data.get("email_id")
+        if not email_id:
+            raise ValueError("No email_id in existing data.")
+        return self.interface.patch_by_email_id(email_id, to_vendor(update_data))
+
 
 def ctms_session():
     """Return a CTMSSession configured from Django settings."""

--- a/basket/news/tests/test_ctms.py
+++ b/basket/news/tests/test_ctms.py
@@ -329,6 +329,51 @@ class ToVendorTests(TestCase):
             ]
         }
 
+    @patch(
+        "basket.news.backends.ctms.newsletter_slugs",
+        return_value=["slug1", "slug2", "slug3", "slug4"],
+    )
+    def test_output_with_unsubscribe(self, mock_nl_slugs):
+        """An 'unsubscribe all' request is detected."""
+        data = {
+            "optout": True,
+            "newsletters": {
+                "slug1": False,
+                "slug2": False,
+                "slug3": False,
+                "slug4": False,
+            },
+        }
+        prepared = to_vendor(data)
+        assert prepared == {
+            "email": {"has_opted_out_of_email": True},
+            "newsletters": "UNSUBSCRIBE",
+        }
+
+    @patch(
+        "basket.news.backends.ctms.newsletter_slugs",
+        return_value=["slug1", "slug2", "slug3", "slug4"],
+    )
+    def test_output_with_manual_unsubscribe_all(self, mock_nl_slugs):
+        """Manually unsubscribing is different from 'unsubscribe all'."""
+        data = {
+            "newsletters": {
+                "slug1": False,
+                "slug2": False,
+                "slug3": False,
+                "slug4": False,
+            },
+        }
+        prepared = to_vendor(data)
+        assert prepared == {
+            "newsletters": [
+                {"name": "slug1", "subscribed": False},
+                {"name": "slug2", "subscribed": False},
+                {"name": "slug3", "subscribed": False},
+                {"name": "slug4", "subscribed": False},
+            ]
+        }
+
     def test_amo_deleted(self):
         """amo_deleted requests that AMO data is deleted."""
         data = {

--- a/basket/news/tests/test_ctms.py
+++ b/basket/news/tests/test_ctms.py
@@ -343,7 +343,7 @@ class CTMSSessionTests(TestCase):
 def mock_interface(expected_call, status_code, response_data, reason=None):
     """Return a CTMSInterface with a mocked session and response"""
     call = expected_call.lower()
-    assert call in set(("post", "put", "get"))
+    assert call in set(("patch", "post", "put", "get"))
     session = Mock(spec_set=[call])
     caller = getattr(session, call)
 

--- a/basket/news/tests/test_ctms.py
+++ b/basket/news/tests/test_ctms.py
@@ -275,6 +275,41 @@ class ToVendorTests(TestCase):
         "basket.news.backends.ctms.newsletter_slugs",
         return_value=["slug1", "slug2", "slug3", "slug4"],
     )
+    def test_newsletter_list_with_source_url(self, mock_nl_slugs):
+        """A newsletter list can have a subscription source URL."""
+        data = {
+            "newsletters": ["slug1", "slug2", "slug3", "other"],
+            "source_url": "  https://example.com",
+        }
+        prepared = to_vendor(data)
+        assert prepared == {
+            "newsletters": [
+                {"name": "slug1", "subscribed": True, "source": "https://example.com"},
+                {"name": "slug2", "subscribed": True, "source": "https://example.com"},
+                {"name": "slug3", "subscribed": True, "source": "https://example.com"},
+            ]
+        }
+
+    @patch(
+        "basket.news.backends.ctms.newsletter_slugs",
+        return_value=["slug1", "slug2", "slug3", "slug4"],
+    )
+    def test_newsletter_list_with_null_source_url(self, mock_nl_slugs):
+        """A null newsletter subscription source URL is ignored."""
+        data = {"newsletters": ["slug1", "slug2", "slug3", "other"], "source_url": None}
+        prepared = to_vendor(data)
+        assert prepared == {
+            "newsletters": [
+                {"name": "slug1", "subscribed": True},
+                {"name": "slug2", "subscribed": True},
+                {"name": "slug3", "subscribed": True},
+            ]
+        }
+
+    @patch(
+        "basket.news.backends.ctms.newsletter_slugs",
+        return_value=["slug1", "slug2", "slug3", "slug4"],
+    )
     def test_newsletter_map(self, mock_nl_slugs):
         """A newsletter map combines subscribe and unsubscribe requests."""
         data = {

--- a/basket/news/tests/test_ctms.py
+++ b/basket/news/tests/test_ctms.py
@@ -294,6 +294,20 @@ class ToVendorTests(TestCase):
             ]
         }
 
+    def test_amo_deleted(self):
+        """amo_deleted requests that AMO data is deleted."""
+        data = {
+            "amo_deleted": True,
+            "amo_id": None,
+            "amo_display_name": "Add-ons Author",
+            "amo_homepage": "firefox/user/98765",
+            "amo_last_login": "2021-01-28",
+            "amo_location": "California",
+            "amo_user": True,
+        }
+        prepared = to_vendor(data)
+        assert prepared == {"amo": "DELETE"}
+
     def test_ignored_fields(self):
         """Some fields exported to SFDC are quietly ignored in CTMS."""
         data = {
@@ -313,7 +327,6 @@ class ToVendorTests(TestCase):
             "cv_first_contribution_date": "2021-03-12",
             "cv_two_day_streak": True,
             "cv_last_active_date": "2021-04-11",
-            "amo_deleted": True,
             "fxa_last_login": "2020-04-11",
         }
         prepared = to_vendor(data)


### PR DESCRIPTION
During the transition phase from Salesforce (SFDC) to CTMS, it is (hopefully) safe to write to CTMS when:

* Creating a new contact. The new SFDC contact will have a matching ``Email_Id__c`` to CTMS's ``email_id``, and BigQuery will not generate a new one.
* Updating a contact where SFDC knows the ``email_id``. BigQuery may update or replace the CTMS contact during bulk imports or updates, but the ``email_id`` will be the same.

Details:

* Add CTMS version of `to_vendor`, to convert Basket-formatted data to CTMS. Some SFDC data is ignored by CTMS, and some conversions are not performed.
* Add `patch_by_email_id` to `CTMSInterface`, to support partial updates.
* Add `add` to `CTMS`, to support adding contacts.
* Add `update` to `CTMS`, to support partial updates of contacts, with some CTMS-specific features:
  - If AMO account deletion is detected, reset AMO data with `{'amo': 'DELETED'}`.
  - If unsubscribe all is detected, use `{'newsletters': 'UNSUBSCRIBE'}` for bulk unsubscribe.
  - If subscribing to individual newsletters, apply `source_url` (if set) to new subscriptions 
* Update `upsert_contact`, to send data to CTMS:
  * When adding a new contact, try to add it to CTMS first, then to SFDC with an `email_id`. If CTMS fails, still add to SFDC without an `email_id`.
  * When updating a contact, update it in SFDC, and if it has an `email_id`, update it in CTMS
* Update `sfdc_add_update` with similar logic, but adding to CTMS only after successfully adding to SFDC

Includes tests for the changes, except for ``sfdc_add_update`` which has no existing tests.