### PR TITLE
Ignore api_key from basket data

### DIFF
--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -135,6 +135,7 @@ DISCARD_BASKET_NAMES = {
     "cv_two_day_streak",
     "cv_last_active_date",
     "fxa_last_login",  # Imported into Acoustic periodically from FxA
+    "api_key",  # Added from authenticated calls
 }
 
 

--- a/basket/news/tests/test_ctms.py
+++ b/basket/news/tests/test_ctms.py
@@ -408,6 +408,7 @@ class ToVendorTests(TestCase):
             "cv_two_day_streak": True,
             "cv_last_active_date": "2021-04-11",
             "fxa_last_login": "2020-04-11",
+            "api_key": "a-basket-api-key",
         }
         prepared = to_vendor(data)
         assert prepared == {}


### PR DESCRIPTION
This appears to be added from authenticated calls, like from Bedrock's preference center.