### PR TITLE
Generate email IDs in CTMS, use safer calls

### DIFF
--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django_statsd.clients import statsd
 
+import sentry_sdk
 from requests_oauthlib import OAuth2Session
 from oauthlib.oauth2 import BackendApplicationClient
 
@@ -594,7 +595,11 @@ class CTMS:
         """
         if not self.interface:
             return None
-        return self.interface.post_to_create(to_vendor(data))
+        try:
+            return self.interface.post_to_create(to_vendor(data))
+        except Exception:
+            sentry_sdk.capture_exception()
+            return None
 
     def update(self, existing_data, update_data):
         """
@@ -609,7 +614,11 @@ class CTMS:
         email_id = existing_data.get("email_id")
         if not email_id:
             raise ValueError("No email_id in existing data.")
-        return self.interface.patch_by_email_id(email_id, to_vendor(update_data))
+        try:
+            return self.interface.patch_by_email_id(email_id, to_vendor(update_data))
+        except Exception:
+            sentry_sdk.capture_exception()
+            return None
 
 
 def ctms_session():

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -564,14 +564,13 @@ def upsert_contact(api_call_type, data, user_data):
             sfdc_add_update.delay(update_data)
         else:
             ctms_data = update_data.copy()
-            email_id = ctms_data["email_id"] = generate_token()
             try:
-                ctms.add(ctms_data)
+                ctms_contact = ctms.add(ctms_data)
             except Exception:
                 sentry_sdk.capture_exception()
             else:
                 # Successfully added to CTMS, send email_id to SFDC
-                update_data["email_id"] = email_id
+                update_data["email_id"] = ctms_contact["email"]["email_id"]
 
             # don't catch exceptions here. SalesforceError subclasses will retry.
             sfdc.add(update_data)
@@ -629,10 +628,19 @@ def sfdc_add_update(update_data, user_data=None):
         sfdc.update(user_data, update_data)
         if user_data.get("email_id"):
             # Only update when CTMS has a matching record
-            ctms.update(user_data, update_data)
+            try:
+                ctms.update(user_data, update_data)
+            except Exception:
+                sentry_sdk.capture_exception()
     else:
-        if not update_data.get("email_id"):
-            update_data["email_id"] = generate_token()
+        ctms_data = update_data.copy()
+        try:
+            ctms_contact = ctms.add(ctms_data)
+        except Exception:
+            sentry_sdk.capture_exception()
+        else:
+            update_data["email_id"] = ctms_contact["email"]["email_id"]
+
         try:
             sfdc.add(update_data)
         except sfapi.SalesforceMalformedRequest as e:  # noqa
@@ -642,17 +650,23 @@ def sfdc_add_update(update_data, user_data=None):
                 # we have a user, delete generated token and email_id
                 # and continue with an update
                 update_data.pop("token", None)
-                update_data.pop("email_id", None)
+                if user_data.get("email_id"):
+                    update_data.pop("email_id", None)
                 sfdc.update(user_data, update_data)
                 if user_data.get("email_id"):
-                    ctms.update(user_data, update_data)
+                    try:
+                        ctms.update(user_data, update_data)
+                    except Exception:
+                        sentry_sdk.capture_exception()
             else:
                 # still no user, try the add one more time
+                try:
+                    ctms_contact = ctms.add(update_data)
+                except Exception:
+                    sentry_sdk.capture_exception()
+                else:
+                    update_data["email_id"] = ctms_contact["email_id"]["email_id"]
                 sfdc.add(update_data)
-                ctms.add(update_data)
-        else:
-            # Add the related CTMS record
-            ctms.add(update_data)
 
 
 @et_task

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -638,8 +638,7 @@ def sfdc_add_update(update_data, user_data=None):
                 # we have a user, delete generated token and email_id
                 # and continue with an update
                 update_data.pop("token", None)
-                if user_data.get("email_id"):
-                    update_data.pop("email_id", None)
+                update_data.pop("email_id", None)
                 sfdc.update(user_data, update_data)
                 if user_data.get("email_id"):
                     ctms.update(user_data, update_data)

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -665,7 +665,7 @@ def sfdc_add_update(update_data, user_data=None):
                 except Exception:
                     sentry_sdk.capture_exception()
                 else:
-                    update_data["email_id"] = ctms_contact["email_id"]["email_id"]
+                    update_data["email_id"] = ctms_contact["email"]["email_id"]
                 sfdc.add(update_data)
 
 

--- a/basket/news/tests/test_upsert_user.py
+++ b/basket/news/tests/test_upsert_user.py
@@ -3,8 +3,6 @@ from uuid import uuid4
 from django.test import TestCase, override_settings
 
 from mock import patch, ANY
-from requests import Response
-from requests.exceptions import HTTPError
 
 from basket.news import models
 from basket.news.tasks import upsert_user
@@ -456,11 +454,7 @@ class UpsertUserTests(TestCase):
     ):
         """When CTMS returns an error for a new contact, the email_id is not sent to SFDC"""
         get_user_data.return_value = None  # Does not exist yet
-        ctms_resp = Response()
-        ctms_resp.status_code = 409
-        ctms_resp._content = '"detail": "Contact already exists"}'
-        ctms_err = HTTPError(response=ctms_resp)
-        ctms_mock.add.side_effect = ctms_err
+        ctms_mock.add.return_value = None  # Conflict on create
         models.Newsletter.objects.create(
             slug="slug",
             title="title",

--- a/basket/news/tests/test_upsert_user.py
+++ b/basket/news/tests/test_upsert_user.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from django.test import TestCase, override_settings
 
 from mock import patch, ANY
@@ -34,6 +36,8 @@ class UpsertUserTests(TestCase):
     ):
         """sending name fields should result in names being passed to SF"""
         get_user_data.return_value = None  # Does not exist yet
+        email_id = str(uuid4())
+        ctms_mock.add.return_value = {"email": {"email_id": email_id}}
         models.Newsletter.objects.create(
             slug="slug",
             title="title",
@@ -55,9 +59,9 @@ class UpsertUserTests(TestCase):
         sfdc_data = data.copy()
         sfdc_data["newsletters"] = {"slug": True}
         sfdc_data["token"] = ANY
-        sfdc_data["email_id"] = ANY
-        sfdc_mock.add.assert_called_with(sfdc_data)
         ctms_mock.add.assert_called_with(sfdc_data)
+        sfdc_data["email_id"] = email_id
+        sfdc_mock.add.assert_called_with(sfdc_data)
 
     def test_update_user_set_works_if_no_newsletters(
         self, get_user_data, sfdc_mock, ctms_mock, confirm_mock,
@@ -284,6 +288,8 @@ class UpsertUserTests(TestCase):
     def test_send_confirm(self, get_user_data, sfdc_mock, ctms_mock, confirm_mock):
         """Subscribing to a newsletter should send a confirm email"""
         get_user_data.return_value = None  # Does not exist yet
+        email_id = str(uuid4())
+        ctms_mock.add.return_value = {"email": {"email_id": email_id}}
         models.Newsletter.objects.create(
             slug="slug",
             title="title",
@@ -303,14 +309,16 @@ class UpsertUserTests(TestCase):
         sfdc_data = data.copy()
         sfdc_data["newsletters"] = {"slug": True}
         sfdc_data["token"] = ANY
-        sfdc_data["email_id"] = ANY
-        sfdc_mock.add.assert_called_with(sfdc_data)
         ctms_mock.add.assert_called_with(sfdc_data)
+        sfdc_data["email_id"] = email_id
+        sfdc_mock.add.assert_called_with(sfdc_data)
         confirm_mock.delay.assert_called_with(self.email, ANY, "en", "moz")
 
     def test_send_fx_confirm(self, get_user_data, sfdc_mock, ctms_mock, confirm_mock):
         """Subscribing to a Fx newsletter should send a Fx confirm email"""
         get_user_data.return_value = None  # Does not exist yet
+        email_id = str(uuid4())
+        ctms_mock.add.return_value = {"email": {"email_id": email_id}}
         models.Newsletter.objects.create(
             slug="slug",
             title="title",
@@ -331,14 +339,16 @@ class UpsertUserTests(TestCase):
         sfdc_data = data.copy()
         sfdc_data["newsletters"] = {"slug": True}
         sfdc_data["token"] = ANY
-        sfdc_data["email_id"] = ANY
-        sfdc_mock.add.assert_called_with(sfdc_data)
         ctms_mock.add.assert_called_with(sfdc_data)
+        sfdc_data["email_id"] = email_id
+        sfdc_mock.add.assert_called_with(sfdc_data)
         confirm_mock.delay.assert_called_with(self.email, ANY, "en", "fx")
 
     def test_send_moz_confirm(self, get_user_data, sfdc_mock, ctms_mock, confirm_mock):
         """Subscribing to a Fx and moz newsletters should send a moz confirm email"""
         get_user_data.return_value = None  # Does not exist yet
+        email_id = str(uuid4())
+        ctms_mock.add.return_value = {"email": {"email_id": email_id}}
         models.Newsletter.objects.create(
             slug="slug",
             title="title",
@@ -368,9 +378,9 @@ class UpsertUserTests(TestCase):
         sfdc_data = data.copy()
         sfdc_data["newsletters"] = {"slug": True, "slug2": True}
         sfdc_data["token"] = ANY
-        sfdc_data["email_id"] = ANY
-        sfdc_mock.add.assert_called_with(sfdc_data)
         ctms_mock.add.assert_called_with(sfdc_data)
+        sfdc_data["email_id"] = email_id
+        sfdc_mock.add.assert_called_with(sfdc_data)
         confirm_mock.delay.assert_called_with(self.email, ANY, "en", "moz")
 
     def test_no_send_confirm_newsletter(
@@ -381,6 +391,8 @@ class UpsertUserTests(TestCase):
         if the newsletter does not require it
         """
         get_user_data.return_value = None  # Does not exist yet
+        email_id = str(uuid4())
+        ctms_mock.add.return_value = {"email": {"email_id": email_id}}
         models.Newsletter.objects.create(
             slug="slug",
             title="title",
@@ -400,10 +412,10 @@ class UpsertUserTests(TestCase):
         sfdc_data = data.copy()
         sfdc_data["newsletters"] = {"slug": True}
         sfdc_data["token"] = ANY
-        sfdc_data["email_id"] = ANY
         sfdc_data["optin"] = True
-        sfdc_mock.add.assert_called_with(sfdc_data)
         ctms_mock.add.assert_called_with(sfdc_data)
+        sfdc_data["email_id"] = email_id
+        sfdc_mock.add.assert_called_with(sfdc_data)
         confirm_mock.delay.assert_not_called()
 
     def test_no_send_confirm_user(
@@ -468,8 +480,6 @@ class UpsertUserTests(TestCase):
         sfdc_data = data.copy()
         sfdc_data["newsletters"] = {"slug": True}
         sfdc_data["token"] = ANY
-        sfdc_data["email_id"] = ANY
         ctms_mock.add.assert_called_with(sfdc_data)
-        del sfdc_data["email_id"]
         sfdc_mock.add.assert_called_with(sfdc_data)
         confirm_mock.delay.assert_called_with(self.email, ANY, "en", "moz")


### PR DESCRIPTION
Fix #686:

* Instead of generating the email ID in Basket, let CTMS generate it, and pass it to SFDC when creating the contact.
* Surround more CTMS calls with exception handlers.
* Re-arrange ``sfdc_add_update`` to also create the CTMS record before it tries to create the SFDC record.