### PR TITLE
Adjust CTMS interface, integrate more CTMS calls

### DIFF
--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -613,7 +613,8 @@ class CTMS:
             return None
         email_id = existing_data.get("email_id")
         if not email_id:
-            raise ValueError("No email_id in existing data.")
+            # TODO: When CTMS is primary, this should be an error
+            return None
         try:
             return self.interface.patch_by_email_id(email_id, to_vendor(update_data))
         except Exception:

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -28,7 +28,7 @@ from silverpop.api import SilverpopResponseException
 from basket.base.utils import email_is_testing
 from basket.news.backends.acoustic import acoustic_tx, acoustic
 from basket.news.backends.common import NewsletterException
-from basket.news.backends.ctms import ctms
+from basket.news.backends.ctms import ctms, CTMSNotFoundByAltIDError
 from basket.news.backends.sfdc import sfdc
 from basket.news.celery import app as celery_app
 from basket.news.models import (
@@ -726,6 +726,12 @@ def update_custom_unsub(token, reason):
         sfdc.update({"token": token}, {"reason": reason})
     except sfapi.SalesforceMalformedRequest:
         # likely the record can't be found. nothing to do.
+        return
+
+    try:
+        ctms.update_by_alt_id("token", token, {"reason": reason})
+    except CTMSNotFoundByAltIDError:
+        # No record found for that token, nothing to do.
         pass
 
 

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -773,8 +773,13 @@ def record_common_voice_update(data):
 
     if user_data:
         sfdc.update(user_data, new_data)
+        ctms.update(user_data, new_data)
     else:
         new_data.update({"email": email, "token": generate_token()})
+        ctms_data = new_data.copy()
+        ctms_contact = ctms.add(ctms_data)
+        if ctms_contact:
+            new_data["email_id"] = ctms_contact["email"]["email_id"]
         sfdc.add(new_data)
 
 

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -597,11 +597,7 @@ def upsert_contact(api_call_type, data, user_data):
         sfdc_add_update.delay(update_data, user_data)
     else:
         sfdc.update(user_data, update_data)
-
-        # During the transition from SFDC to CTMS, only update if there is a
-        # matching CTMS record
-        if user_data.get("email_id"):
-            ctms.update(user_data, update_data)
+        ctms.update(user_data, update_data)
 
     if send_confirm and settings.SEND_CONFIRM_MESSAGES:
         send_confirm_message.delay(
@@ -620,9 +616,7 @@ def sfdc_add_update(update_data, user_data=None):
     # TODO remove after maintenance is over and queue is processed
     if user_data:
         sfdc.update(user_data, update_data)
-        if user_data.get("email_id"):
-            # Only update when CTMS has a matching record
-            ctms.update(user_data, update_data)
+        ctms.update(user_data, update_data)
     else:
         ctms_data = update_data.copy()
         ctms_contact = ctms.add(ctms_data)
@@ -640,8 +634,7 @@ def sfdc_add_update(update_data, user_data=None):
                 update_data.pop("token", None)
                 update_data.pop("email_id", None)
                 sfdc.update(user_data, update_data)
-                if user_data.get("email_id"):
-                    ctms.update(user_data, update_data)
+                ctms.update(user_data, update_data)
             else:
                 # still no user, try the add one more time
                 ctms_contact = ctms.add(update_data)

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -472,6 +472,11 @@ def update_get_involved(
 def update_user_meta(token, data):
     """Update a user's metadata, not newsletters"""
     sfdc.update({"token": token}, data)
+    try:
+        ctms.update_by_alt_id("token", token, data)
+    except CTMSNotFoundByAltIDError:
+        # TODO: raise this exception when CTMS is primary data source
+        pass
 
 
 @et_task

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -701,6 +701,7 @@ def confirm_user(token):
         raise BasketError("token has no email in ET")
 
     sfdc.update(user_data, {"optin": True})
+    ctms.update(user_data, {"optin": True})
 
 
 @et_task

--- a/basket/news/tests/test_ctms.py
+++ b/basket/news/tests/test_ctms.py
@@ -905,8 +905,14 @@ class CTMSTests(TestCase):
         )
 
     def test_update_email_id_not_in_existing_data(self):
-        """CTMS.update requires an email_id in existing data."""
+        """
+        CTMS.update requires an email_id in existing data.
+
+        TODO: This should raise an exception after the SDFC to CTMS
+        transition. However, the calling code is simplier if it does
+        nothing when there is no existing email_id.
+        """
         ctms = CTMS("interface should not be called")
         user_data = {"token": "an-existing-user"}
         update_data = {"first_name": "Elizabeth", "email_id": "a-new-email-id"}
-        self.assertRaises(ValueError, ctms.update, user_data, update_data)
+        assert ctms.update(user_data, update_data) is None

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -36,6 +36,7 @@ from basket.news.tasks import (
     get_lock,
     RetryTask,
     update_custom_unsub,
+    update_user_meta,
 )
 from basket.news.utils import iso_format_unix_timestamp
 
@@ -1638,3 +1639,15 @@ class TestUpdateCustomUnsub(TestCase):
         mock_sfdc.update.assert_called_once_with(
             {"token": self.token}, {"reason": self.reason}
         )
+
+
+@override_settings(TASK_LOCKING_ENABLE=False)
+@patch("basket.news.tasks.sfdc")
+class TestUpdateUserMeta(TestCase):
+    token = "the-token"
+    data = {"first_name": "Edmund", "last_name": "Gettier"}
+
+    def test_normal(self, mock_sfdc):
+        """The data is updated for the token"""
+        update_user_meta(self.token, self.data)
+        mock_sfdc.update.assert_called_once_with({"token": self.token}, self.data)

--- a/basket/settings.py
+++ b/basket/settings.py
@@ -468,7 +468,11 @@ if OIDC_ENABLE:
     MIDDLEWARE += ("basket.news.middleware.OIDCSessionRefreshMiddleware",)
     LOGIN_REDIRECT_URL = "/admin/"
 
-if sys.argv[0].endswith("py.test") or (len(sys.argv) > 1 and sys.argv[1] == "test"):
+if (
+    sys.argv[0].endswith("py.test")
+    or sys.argv[0].endswith("pytest")
+    or (len(sys.argv) > 1 and sys.argv[1] == "test")
+):
     # stuff that's absolutely required for a test run
     CELERY_TASK_ALWAYS_EAGER = True
     SFDC_SETTINGS.pop("username", None)


### PR DESCRIPTION
This PR makes several changes, which could be reviewed by commit:

* Adjust and update the CTMS interface:
  - Add ``CTMSError`` as the base exception for CTMS exceptions, as well as further derived exceptions. This work is not complete, and some exceptions are still raised directly from ``requests``. The goal is to start adding some exception handling into the basket code.
  - ``ctms.update`` now does nothing if ``email_id`` isn't set. This simplifies the calling code to look more like what it should after SFDC is retired
  - New ``ctms.update_by_alt_id`` method. This combines fetching a record by an ID other than ``email_id``, like the basket token, and then running a partial update. This may become a single API call  if CTMS grows another endpoint.
* Add basic tests for untested tasks ``update_custom_unsub`` and ``update_user_meta``
* Update tasks to also call CTMS:
  - ``confirm_user`` - Also try to update CTMS record
  - ``update_custom_unsub`` - Also try to update CTMS record
  - ``update_user_meta`` - Also try to update CTMS record
  - ``record_common_voice_update`` - Also create or (try to) update CTMS record
* Allow ``pytest`` as well as ``py.test`` to adjust Django settings for tests. 

This makes progress on issue #684, but leaves several tasks still to convert (called by ``process_donations_queue``, ``process_fxa_queue``, and ``amo_sync_addon``)