### PR TITLE
Integrate CTMS calls for remaining tasks

### DIFF
--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -80,7 +80,7 @@ CTMS_TO_BASKET_NAMES = {
         # Need more information about the future MoFo integrations
         "mofo_email_id": None,
         "mofo_contact_id": None,
-        "mofo_relevant": None,
+        "mofo_relevant": "mofo_relevant",
     },
     "vpn_waitlist": {"geo": "fpn_country", "platform": "fpn_platform"},
 }

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -30,6 +30,7 @@ from basket.news.backends.acoustic import acoustic_tx, acoustic
 from basket.news.backends.common import NewsletterException
 from basket.news.backends.ctms import ctms, CTMSNotFoundByAltIDError
 from basket.news.backends.sfdc import sfdc
+from basket.news.backends.sfdc import from_vendor as from_sfdc
 from basket.news.celery import app as celery_app
 from basket.news.models import (
     FailedTask,
@@ -318,6 +319,13 @@ def fxa_direct_update_contact(fxa_id, data):
         else:
             # otherwise it's something else and we should potentially retry
             raise
+
+    basket_data = from_sfdc(data)
+    try:
+        ctms.update_by_alt_id("fxa_id", fxa_id, basket_data)
+    except CTMSNotFoundByAltIDError:
+        # No associated record found, skip this update.
+        pass
 
 
 @et_task

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -1263,6 +1263,7 @@ def amo_check_user_for_deletion(user_id):
     )
     if not addons["records"]:
         sfdc.update({"id": user_id}, {"amo_id": None, "amo_user": False})
+        ctms.update_by_alt_id("sfdc_id", user_id, {"amo_deleted": True})
 
 
 @et_task

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -1123,10 +1123,20 @@ def process_petition_signature(data):
     user_data = get_user_data(email=data["email"], extra_fields=["id"])
     if user_data:
         sfdc.update(user_data, contact_data)
+        ctms_data = contact_data.copy()
+        del ctms_data["_set_subscriber"]
+        ctms.update(user_data, ctms_data)
     else:
         contact_data["token"] = generate_token()
         contact_data["email"] = data["email"]
+        ctms_data = contact_data.copy()
         contact_data["record_type"] = settings.DONATE_CONTACT_RECORD_TYPE
+
+        del ctms_data["_set_subscriber"]
+        contact = ctms.add(ctms_data)
+        if contact:
+            contact_data["email_id"] = contact["email"]["email_id"]
+
         sfdc.add(contact_data)
         # fetch again to get ID
         user_data = get_user_data(email=data.get("email"), extra_fields=["id"])

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -1387,6 +1387,7 @@ def get_fxa_user_data(fxa_id, email):
         # If email doesn't match, update FxA primary email field with the new email.
         if user_data_fxa["email"] != email:
             sfdc.update(user_data_fxa, {"fxa_primary_email": email})
+            ctms.update(user_data_fxa, {"fxa_primary_email": email})
 
     # if we still don't have user data try again with email this time
     if not user_data:

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -951,10 +951,20 @@ def process_donation(data):
             )
         ):
             sfdc.update(user_data, contact_data)
+            ctms_data = contact_data.copy()
+            del ctms_data["_set_subscriber"]
+            ctms.update(user_data, ctms_data)
     else:
         contact_data["token"] = generate_token()
         contact_data["email"] = data["email"]
         contact_data["record_type"] = settings.DONATE_CONTACT_RECORD_TYPE
+
+        ctms_data = contact_data.copy()
+        del ctms_data["_set_subscriber"]
+        del ctms_data["record_type"]
+        contact = ctms.add(ctms_data)
+        if contact:
+            contact_data["email_id"] = contact["email"]["email_id"]
 
         # returns a dict with the new ID but no other user data, but that's enough here
         user_data = sfdc.add(contact_data)

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -932,8 +932,10 @@ DONATION_NEW_FIELDS = {
 @et_task
 def process_donation(data):
     get_lock(data["email"])
-    # tells the backend to leave the "subscriber" flag alone
-    contact_data = {"_set_subscriber": False}
+    contact_data = {
+        "_set_subscriber": False,  # SFDC, leave "subscriber" flag alone
+        "mofo_relevant": True,  # CTMS, set a MoFo relevant contact
+    }
     # do "or ''" because data can contain None values
     first_name = (data.get("first_name") or "").strip()
     last_name = (data.get("last_name") or "").strip()
@@ -1133,7 +1135,10 @@ def process_petition_signature(data):
     data = data["form"]
     get_lock(data["email"])
     # tells the backend to leave the "subscriber" flag alone
-    contact_data = {"_set_subscriber": False}
+    contact_data = {
+        "_set_subscriber": False,  # SFDC: leave the "subscriber" flag alone
+        "mofo_relevant": True,  # CTMS: set contact as MoFo relevant
+    }
     contact_data.update({k: data[k] for k in PETITION_CONTACT_FIELDS if data.get(k)})
 
     user_data = get_user_data(email=data["email"], extra_fields=["id"])
@@ -1149,6 +1154,7 @@ def process_petition_signature(data):
         contact_data["record_type"] = settings.DONATE_CONTACT_RECORD_TYPE
 
         del ctms_data["_set_subscriber"]
+        ctms_data["mofo_relevant"] = True
         contact = ctms.add(ctms_data)
         if contact:
             contact_data["email_id"] = contact["email"]["email_id"]

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -287,7 +287,7 @@ def fxa_email_changed(data):
         # message older than our last update for this UID
         return
 
-    # Update SFDC
+    # Update SFDC / CTMS
     user_data = get_user_data(fxa_id=fxa_id, extra_fields=["id"])
     if user_data:
         sfdc.update(user_data, {"fxa_primary_email": email})
@@ -300,7 +300,12 @@ def fxa_email_changed(data):
             ctms.update(user_data, {"fxa_id": fxa_id, "fxa_primary_email": email})
         else:
             # No matching record for Email or FxA ID. Create one.
-            data = {"email": email, "fxa_id": fxa_id, "fxa_primary_email": email}
+            data = {
+                "email": email,
+                "token": generate_token(),
+                "fxa_id": fxa_id,
+                "fxa_primary_email": email,
+            }
             ctms_data = data.copy()
             contact = ctms.add(ctms_data)
             if contact:

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -1110,6 +1110,7 @@ def process_donation_receipt(data):
 
 @et_task
 def process_newsletter_subscribe(data):
+    """Process a MoFo newsletter subscription."""
     data = data["form"]
     data["lang"] = get_best_supported_lang(data["lang"])
     upsert_user(SUBSCRIBE, data)

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -1241,6 +1241,7 @@ def upsert_amo_user_data(data, user_sync=False):
         amo_data["amo_id"] = None
 
     sfdc.update(user, amo_data)
+    ctms.update(user, amo_data)
     return user
 
 

--- a/basket/news/tests/test_ctms.py
+++ b/basket/news/tests/test_ctms.py
@@ -112,6 +112,7 @@ SAMPLE_BASKET_FORMAT = {
     "lang": "en",
     "last_modified_date": "2021-01-28T21:26:57.511Z",
     "last_name": "Doe",
+    "mofo_relevant": False,
     "newsletters": ["mozilla-welcome"],
     "optin": True,
     "optout": False,
@@ -179,6 +180,7 @@ class ToVendorTests(TestCase):
                 "lang": "en,en-US",
                 "primary_email": "my-fxa-acct@example.com",
             },
+            "mofo": {"mofo_relevant": False},
             "newsletters": [{"name": "mozilla-welcome", "subscribed": True}],
             "vpn_waitlist": {"geo": "fr", "platform": "ios,mac"},
         }

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -73,7 +73,7 @@ class ProcessPetitionSignatureTests(TestCase):
 
     def _get_contact_data(self, data):
         data = data["form"]
-        contact_data = {"_set_subscriber": False}
+        contact_data = {"_set_subscriber": False, "mofo_relevant": True}
         contact_data.update({k: data[k] for k in PETITION_CONTACT_FIELDS if k in data})
         return contact_data
 
@@ -485,9 +485,12 @@ class ProcessDonationTests(TestCase):
         data["last_name"] = "Donnie"
         process_donation(data)
         sfdc_mock.update.assert_called_with(
-            gud_mock(), {"_set_subscriber": False, "last_name": "Donnie"},
+            gud_mock(),
+            {"_set_subscriber": False, "mofo_relevant": True, "last_name": "Donnie"},
         )
-        ctms_mock.update.assert_called_with(gud_mock(), {"last_name": "Donnie"})
+        ctms_mock.update.assert_called_with(
+            gud_mock(), {"last_name": "Donnie", "mofo_relevant": True}
+        )
 
     def test_name_splitting(self, ctms_mock, sfdc_mock, gud_mock):
         data = self.donate_data.copy()
@@ -503,6 +506,7 @@ class ProcessDonationTests(TestCase):
                 "email": "dude@example.com",
                 "first_name": "Theodore Donald",
                 "last_name": "Kerabatsos",
+                "mofo_relevant": True,
             }
         )
         sfdc_mock.add.assert_called_with(
@@ -514,6 +518,7 @@ class ProcessDonationTests(TestCase):
                 "first_name": "Theodore Donald",
                 "last_name": "Kerabatsos",
                 "email_id": email_id,
+                "mofo_relevant": True,
             }
         )
 
@@ -529,7 +534,9 @@ class ProcessDonationTests(TestCase):
         del data["first_name"]
         data["last_name"] = "  "
         process_donation(data)
-        ctms_mock.add.assert_called_with({"token": ANY, "email": "dude@example.com"})
+        ctms_mock.add.assert_called_with(
+            {"token": ANY, "email": "dude@example.com", "mofo_relevant": True}
+        )
         sfdc_mock.add.assert_called_with(
             {
                 "_set_subscriber": False,
@@ -537,6 +544,7 @@ class ProcessDonationTests(TestCase):
                 "email": "dude@example.com",
                 "record_type": ANY,
                 "email_id": email_id,
+                "mofo_relevant": True,
             }
         )
 
@@ -552,7 +560,9 @@ class ProcessDonationTests(TestCase):
         del data["first_name"]
         data["last_name"] = None
         process_donation(data)
-        ctms_mock.add.assert_called_with({"token": ANY, "email": "dude@example.com"})
+        ctms_mock.add.assert_called_with(
+            {"token": ANY, "email": "dude@example.com", "mofo_relevant": True}
+        )
         sfdc_mock.add.assert_called_with(
             {
                 "_set_subscriber": False,
@@ -560,6 +570,7 @@ class ProcessDonationTests(TestCase):
                 "email": "dude@example.com",
                 "record_type": ANY,
                 "email_id": email_id,
+                "mofo_relevant": True,
             }
         )
 
@@ -575,6 +586,7 @@ class ProcessDonationTests(TestCase):
                 "email": "dude@example.com",
                 "first_name": "Jeffery",
                 "last_name": "Lebowski",
+                "mofo_relevant": True,
             }
         )
         sfdc_mock.add.assert_called_with(
@@ -585,6 +597,7 @@ class ProcessDonationTests(TestCase):
                 "first_name": "Jeffery",
                 "last_name": "Lebowski",
                 "record_type": ANY,
+                "mofo_relevant": True,
             }
         )
 
@@ -602,10 +615,12 @@ class ProcessDonationTests(TestCase):
                 "_set_subscriber": False,
                 "first_name": "Jeffery",
                 "last_name": "Lebowski",
+                "mofo_relevant": True,
             },
         )
         ctms_mock.update.assert_called_with(
-            gud_mock(), {"first_name": "Jeffery", "last_name": "Lebowski"},
+            gud_mock(),
+            {"first_name": "Jeffery", "last_name": "Lebowski", "mofo_relevant": True},
         )
 
         sfdc_mock.reset_mock()

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -1291,6 +1291,7 @@ class FxAEmailChangedTests(TestCase):
         ctms_mock.add.assert_called_with(
             {
                 "email": data["email"],
+                "token": ANY,
                 "fxa_id": data["uid"],
                 "fxa_primary_email": data["email"],
             },
@@ -1298,6 +1299,7 @@ class FxAEmailChangedTests(TestCase):
         sfdc_mock.add.assert_called_with(
             {
                 "email_id": email_id,
+                "token": ANY,
                 "email": data["email"],
                 "fxa_id": data["uid"],
                 "fxa_primary_email": data["email"],
@@ -1327,6 +1329,7 @@ class FxAEmailChangedTests(TestCase):
         ctms_mock.add.assert_called_with(
             {
                 "email": data["email"],
+                "token": ANY,
                 "fxa_id": data["uid"],
                 "fxa_primary_email": data["email"],
             },
@@ -1334,6 +1337,7 @@ class FxAEmailChangedTests(TestCase):
         sfdc_mock.add.assert_called_with(
             {
                 "email": data["email"],
+                "token": ANY,
                 "fxa_id": data["uid"],
                 "fxa_primary_email": data["email"],
             },

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -1171,7 +1171,7 @@ class FxAEmailChangedTests(TestCase):
         # ts higher in cache, should no-op
         gud_mock.return_value = {"id": "1234"}
         fxa_email_changed(data)
-        sfdc_mock.upsert_row.assert_not_called()
+        sfdc_mock.update.assert_not_called()
         ctms_mock.update.assert_not_called()
 
     def test_timestamps_newer_message(self, cache_mock, gud_mock, sfdc_mock, ctms_mock):
@@ -1546,7 +1546,7 @@ class AMOSyncAddonTests(TestCase):
             ],
         )
         # it should update the 2nd user that has no returned records
-        sfdc_mock.update.called_once_with(
+        sfdc_mock.update.assert_called_once_with(
             {"id": "A4322"}, {"amo_id": None, "amo_user": False},
         )
         sfdc_mock.dev_addon.delete.has_calls([call(1234), call(1235)])

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -1783,10 +1783,11 @@ class TestUpdateUserMeta(TestCase):
         )
 
 
+@patch("basket.news.tasks.ctms", spec_set=["update"])
 @patch("basket.news.tasks.sfdc", spec_set=["update"])
 @patch("basket.news.tasks.get_user_data")
 class TestGetFxaUserData(TestCase):
-    def test_found_by_fxa_id_email_match(self, mock_gud, mock_sfdc):
+    def test_found_by_fxa_id_email_match(self, mock_gud, mock_sfdc, mock_ctms):
         """A user can be found by FxA ID."""
         user_data = {
             "id": "1234",
@@ -1801,8 +1802,9 @@ class TestGetFxaUserData(TestCase):
 
         mock_gud.assert_called_once_with(fxa_id="123", extra_fields=["id"])
         mock_sfdc.update.assert_not_called()
+        mock_ctms.update.assert_not_called()
 
-    def test_found_by_fxa_id_email_mismatch(self, mock_gud, mock_sfdc):
+    def test_found_by_fxa_id_email_mismatch(self, mock_gud, mock_sfdc, mock_ctms):
         """If the FxA user has a different FxA email, set fxa_primary_email."""
         user_data = {
             "id": "1234",
@@ -1819,8 +1821,11 @@ class TestGetFxaUserData(TestCase):
         mock_sfdc.update.assert_called_once_with(
             user_data, {"fxa_primary_email": "fxa@example.com"}
         )
+        mock_ctms.update.assert_called_once_with(
+            user_data, {"fxa_primary_email": "fxa@example.com"}
+        )
 
-    def test_miss_by_fxa_id(self, mock_gud, mock_sfdc):
+    def test_miss_by_fxa_id(self, mock_gud, mock_sfdc, mock_ctms):
         """If the FxA user has a different FxA email, set fxa_primary_email."""
         user_data = {
             "id": "1234",
@@ -1835,7 +1840,8 @@ class TestGetFxaUserData(TestCase):
         assert mock_gud.call_count == 2
         mock_gud.assert_any_call(fxa_id="123", extra_fields=["id"])
         mock_gud.assert_called_with(email="test@example.com", extra_fields=["id"])
-        mock_sfdc.update.assert_not_called()
+        mock_sfdc.update.asser
+        mock_ctms.update.assert_not_called()
 
 
 @patch("basket.news.tasks.sfdc", content=Mock(spec_set=["update"]))


### PR DESCRIPTION
* Add tests for ``fxa_delete`` and ``get_fxa_user_data``
* Fix some test assertions
* Convert the tasks called by ``process_donations_queue`` to use CTMS:
  * ``process_donation``
  * ``process_petition_signature``
* Convert the tasks called by ``process_fxa_queue`` to use CTMS:
  - ``fxa_email_changed``
  - ``fxa_direct_update_contact`` (only called by ``fxa_delete``)
  - ``get_fxa_user_data``
* Convert the tasks called by ``amo_sync_addon`` to use CTMS:
  - ``amo_check_user_for_deletion``
  - ``upsert_amo_user_data``

This fixes #684.

This work brought up some questions:
* Should we be marking ``mofo_relevant=True`` (CTMS field) from ``process_donation`` and ``process_petition_signature``?
* Should ``fxa_email_changed`` be generating a basket token for new records?