### PR TITLE
CTMS.updates - distribute newsletter settings, allow update to unset values

### DIFF
--- a/basket/news/tests/test_ctms.py
+++ b/basket/news/tests/test_ctms.py
@@ -268,6 +268,29 @@ class ToVendorTests(TestCase):
         prepared = to_vendor(data)
         assert prepared == {}
 
+    def test_allow_rewrite_to_empty(self):
+        """Allow setting to an empty string or None if there is an existing value"""
+        existing_data = {
+            "first_name": "Walter",
+            "last_name": "Sobchak",
+            "reason": "",
+            "fxa_id": "12345",
+            "amo_id": 54321,
+        }
+        data = {
+            "first_name": " ",
+            "last_name": "\t",
+            "reason": "",
+            "fxa_id": None,
+            "amo_id": None,
+        }
+        prepared = to_vendor(data, existing_data)
+        assert prepared == {
+            "amo": {"user_id": None},
+            "email": {"first_name": "", "last_name": ""},
+            "fxa": {"fxa_id": None},
+        }
+
     @patch(
         "basket.news.backends.ctms.newsletter_slugs",
         return_value=["slug1", "slug2", "slug3", "slug4"],


### PR DESCRIPTION
To fix #685, when subscribing to a newsletter, apply the format (`T` for text, `H` for HTML) and language to the subscription as well. This is taken from the update data, and falls back to the user's current setting if not provided. The user's current language setting is validated, so an invalid language is set to `en` (English).

To fix #687, when a user has a non-empty value for a setting, allow it to be set to an empty string or None. This allows clearing parameters like names and IDs.