### PR TITLE
Add privacy to CTMS ignored fields list

### DIFF
--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -140,8 +140,10 @@ DISCARD_BASKET_NAMES = {
     "cv_first_contribution_date",
     "cv_two_day_streak",
     "cv_last_active_date",
+    #
     "fxa_last_login",  # Imported into Acoustic periodically from FxA
     "api_key",  # Added from authenticated calls
+    "privacy",  # Common in newsletter forms as privacy policy checkbox
 }
 
 

--- a/basket/news/tests/test_ctms.py
+++ b/basket/news/tests/test_ctms.py
@@ -522,6 +522,7 @@ class ToVendorTests(TestCase):
             "cv_last_active_date": "2021-04-11",
             "fxa_last_login": "2020-04-11",
             "api_key": "a-basket-api-key",
+            "privacy": True,
         }
         prepared = to_vendor(data)
         assert prepared == {}


### PR DESCRIPTION
Many newsletter forms have a required checkbox 'privacy' for reading the privacy policy, ignored by SFDC and other basket code.