### PR TITLE
CTMS.get: Try SFDC ID last, and try multiple IDs

### DIFF
--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -632,10 +632,10 @@ class CTMS:
         email_id=None,
         token=None,
         email=None,
-        sfdc_id=None,
         fxa_id=None,
         mofo_email_id=None,
         amo_id=None,
+        sfdc_id=None,
     ):
         """
         Get a contact record, using the first ID provided.
@@ -643,10 +643,10 @@ class CTMS:
         @param email_id: CTMS email ID
         @param token: external ID
         @param email: email address
-        @param sfdc_id: legacy SFDC ID
         @param fxa_id: external ID from FxA
         @param mofo_email_id: external ID from MoFo
         @param amo_id: external ID from AMO
+        @param sfdc_id: legacy SFDC ID
         @return: dict, or None if disabled
         @raises CTMSNoIds: no IDs are set
         @raises CTMSMultipleContacts:: multiple contacts returned
@@ -661,14 +661,14 @@ class CTMS:
                 id_name, id_value = "basket_token", token
             elif email:
                 id_name, id_value = "primary_email", email
-            elif sfdc_id:
-                id_name, id_value = "sfdc_id", sfdc_id
             elif fxa_id:
                 id_name, id_value = "fxa_id", fxa_id
             elif mofo_email_id:
                 id_name, id_value = "mofo_email_id", mofo_email_id
             elif amo_id:
                 id_name, id_value = "amo_user_id", amo_id
+            elif sfdc_id:
+                id_name, id_value = "sfdc_id", sfdc_id
             else:
                 raise CTMSNoIdsError(
                     required_ids=(

--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -448,12 +448,11 @@ class CTMSInterface:
         "email_id",
         "basket_token",
         "primary_email",
-        "sfdc_id",
         "fxa_id",
         "mofo_email_id",
     ]
     # Identifiers that can be shared by multiple CTMS records
-    shared_ids = ["mofo_contact_id", "amo_user_id", "fxa_primary_email"]
+    shared_ids = ["sfdc_id", "mofo_contact_id", "amo_user_id", "fxa_primary_email"]
     all_ids = unique_ids + shared_ids
 
     def __init__(self, session):


### PR DESCRIPTION
The SFDC ID is being tried before the AMO and FxA IDs, which may be resulting in more CTMS misses than anticipated. In the BQ import, some records have multiple SFDC IDs, so it is no longer treated as unique.

When Basket calls ``CTMS.get`` with multiple alternate IDs (not CTMS's primary `email_id`), call CTMS for each ID value, and return the first result with a single contact.

This should fix issue #697