### PR TITLE
Implement CTMS-Only mode with `SFDC_ENABLED=False`

### DIFF
--- a/basket/news/backends/sfdc.py
+++ b/basket/news/backends/sfdc.py
@@ -348,8 +348,15 @@ class RefreshingSFType(RefreshingSFMixin, sfapi.SFType):
         )
 
 
+class SFDCDisabled(RuntimeError):
+    """SFDC called but disabled."""
+
+
 class SFDC:
     def _get_type(self, name):
+        if not settings.SFDC_ENABLED:
+            raise SFDCDisabled("SFDC is not enabled")
+
         if not settings.SFDC_SETTINGS.get("username"):
             return None
 
@@ -409,6 +416,9 @@ class SFDC:
         @param fxa_id: external ID from FxA
         @return: dict
         """
+        if not settings.SFDC_ENABLED:
+            raise SFDCDisabled("SFDC is not enabled")
+
         arg_values = locals()
         args = ("token", "email", "payee_id", "amo_id", "fxa_id")
         field = None
@@ -436,6 +446,9 @@ class SFDC:
         @param data: user data to add as a new contact.
         @return: None
         """
+        if not settings.SFDC_ENABLED:
+            return None
+
         if not data.get("last_name", "").strip():
             data["last_name"] = LAST_NAME_DEFAULT_VALUE
 
@@ -450,6 +463,9 @@ class SFDC:
         @param data: dict of user data
         @return: None
         """
+        if not settings.SFDC_ENABLED:
+            return None
+
         # need a copy because we'll modify it
         data = data.copy()
         if "id" in record:

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -1000,11 +1000,17 @@ def process_donation(data):
         if contact:
             contact_data["email_id"] = contact["email"]["email_id"]
 
+        if not settings.SFDC_ENABLED:
+            return
+
         # returns a dict with the new ID but no other user data, but that's enough here
         user_data = sfdc.add(contact_data)
         if not user_data.get("id"):
             # retry here to make sure we associate the donation data with the proper account
             raise RetryTask("User not yet available")
+
+    if not settings.SFDC_ENABLED:
+        return
 
     # add opportunity
     donation = {

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -498,8 +498,8 @@ def update_user_meta(token, data):
     try:
         ctms.update_by_alt_id("token", token, data)
     except CTMSNotFoundByAltIDError:
-        # TODO: raise this exception when CTMS is primary data source
-        pass
+        if not settings.SFDC_ENABLED:
+            raise
 
 
 @et_task

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -1313,6 +1313,8 @@ def amo_check_user_for_deletion(user_id):
 
 @et_task
 def amo_sync_addon(data):
+    if not settings.SFDC_ENABLED:
+        return
     data = deepcopy(data)
     if data["status"] == "deleted":
         try:

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -1163,7 +1163,9 @@ PETITION_CONTACT_FIELDS = [
 @et_task
 def process_petition_signature(data):
     """
-    Add petition signature to SFDC
+    Add petition signature to CTMS / SFDC
+
+    If SFDC is enabled, a campaign member record is created.
     """
     data = data["form"]
     get_lock(data["email"])
@@ -1209,6 +1211,9 @@ def process_petition_signature(data):
                 "source_url": data["source_url"],
             },
         )
+
+    if not settings.SFDC_ENABLED:
+        return
 
     campaign_id = data["campaign_id"]
     # Fix a specific issue with a specific campaign where the ID was entered without

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -29,7 +29,7 @@ from basket.base.utils import email_is_testing
 from basket.news.backends.acoustic import acoustic_tx, acoustic
 from basket.news.backends.common import NewsletterException
 from basket.news.backends.ctms import ctms, CTMSNotFoundByAltIDError
-from basket.news.backends.sfdc import sfdc
+from basket.news.backends.sfdc import sfdc, SFDCDisabled
 from basket.news.backends.sfdc import from_vendor as from_sfdc
 from basket.news.celery import app as celery_app
 from basket.news.models import (
@@ -332,6 +332,8 @@ def fxa_direct_update_contact(fxa_id, data):
         else:
             # otherwise it's something else and we should potentially retry
             raise
+    except SFDCDisabled:
+        pass
 
     basket_data = from_sfdc(data)
     try:

--- a/basket/news/templates/news/donation_notify_email.txt
+++ b/basket/news/templates/news/donation_notify_email.txt
@@ -1,4 +1,4 @@
-A donation transaction update failed to apply because it could not be found in Salesforce.
+A donation transaction update failed to apply because {{ fail_reason }}.
 
 Transaction ID: {{ txn_id }}
 Type Lost:      {{ type_lost }}

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -1941,12 +1941,27 @@ class TestUpdateUserMeta(TestCase):
             "token", self.token, self.data
         )
 
+    @override_settings(SFDC_ENABLED=True)
     def test_no_ctms_record(self, mock_sfdc, mock_ctms):
         """If there is no CTMS record, CTMS updates are skipped."""
         mock_ctms.update_by_alt_id.side_effect = CTMSNotFoundByAltIDError(
             "token", self.token
         )
         update_user_meta(self.token, self.data)
+        mock_sfdc.update.assert_called_once_with({"token": self.token}, self.data)
+        mock_ctms.update_by_alt_id.assert_called_once_with(
+            "token", self.token, self.data
+        )
+
+    @override_settings(SFDC_ENABLED=False)
+    def test_no_ctms_record_with_sfdc_disabled(self, mock_sfdc, mock_ctms):
+        """If there is no CTMS record, an exception is raised."""
+        mock_ctms.update_by_alt_id.side_effect = CTMSNotFoundByAltIDError(
+            "token", self.token
+        )
+        self.assertRaises(
+            CTMSNotFoundByAltIDError, update_user_meta, self.token, self.data
+        )
         mock_sfdc.update.assert_called_once_with({"token": self.token}, self.data)
         mock_ctms.update_by_alt_id.assert_called_once_with(
             "token", self.token, self.data

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -1579,6 +1579,7 @@ class CommonVoiceGoalsTests(TestCase):
         ctms_mock.update.assert_called_with(gud_mock(), update_data)
 
 
+@override_settings(SFDC_ENABLED=True)
 @patch("basket.news.tasks.ctms", spec_set=["update_by_alt_id"])
 @patch("basket.news.tasks.sfdc")
 @patch("basket.news.tasks.upsert_amo_user_data")
@@ -1771,6 +1772,14 @@ class AMOSyncAddonTests(TestCase):
         )
         sfdc_mock.dev_addon.delete.has_calls([call(1234), call(1235)])
         sfdc_mock.addon.delete.assert_called_with("A9876")
+
+    @override_settings(SFDC_ENABLED=False)
+    def test_update_addon_sfdc_disabled(self, uaud_mock, sfdc_mock, ctms_mock):
+        amo_sync_addon(self.amo_data)
+        uaud_mock.assert_not_called()
+        sfdc_mock.addon.upsert.assert_not_called()
+        sfdc_mock.dev_addon.upsert.assert_not_called()
+        ctms_mock.update_by_alt_id.assert_not_called()
 
 
 @patch("basket.news.tasks.ctms")

--- a/basket/settings.py
+++ b/basket/settings.py
@@ -226,6 +226,8 @@ SFDC_SETTINGS = {
     "security_token": config("SFDC_SEC_TOKEN", None),
     "domain": "test" if SFDC_USE_SANDBOX else "login",
 }
+default_sfdc_enabled = bool(SFDC_SETTINGS["username"])
+SFDC_ENABLED = config("SFDC_ENABLED", default_sfdc_enabled, cast=bool)
 # default SFDC sessions timeout after 2 hours of inactivity. so they never timeout on
 # prod. Let's make it every 4 hours by default.
 SFDC_SESSION_TIMEOUT = config("SFDC_SESSION_TIMEOUT", 60 * 60 * 4, cast=int)


### PR DESCRIPTION
For issue #696, implement CTMS-Only mode by adding a new setting `SFDC_ENABLED`, which defaults to `True` if SFDC_USERNAME is set. When it is `False`, several things change:

* ``backends.sfdc.sfdc`` raises a new error ``SFDCDisabled`` if ``sfdc.get`` is called or a low-level SFDC type class is allocated (like ``sfdc.contact``).
* ``backends.ctms.ctms`` raises a new error ``CTMSNotConfigured`` if methods are called and the CTMS API key is not configured.
* ``utils.get_user_data`` catches ``SFDCDisabled`` and uses CTMS as the primary user data source. Several exceptions are re-raised as ``NewsletterException`` instead of being captured and ignored. The ignored-fields logic now runs against the CTMS user data as well.
* Several tasks change implicitly because user data comes from CTMS, and ``sfdc.add`` and ``sfdc.update`` do nothing.
* ``task.update_user_meta`` raises an exception if a matching CTMS record is not found
* ``process_donation_event`` sends an email to ``DONATE_NOTIFY_EMAIL``
* ``process_donation`` skips adding opportunities to SFDC
* ``process_petition_signature`` skips adding campaign members to SFDC
* ``amo_sync_addon`` does not process any data