### PR TITLE
ctms.to_vendor: Log in sentry rather than raise exception on unknown keys

### DIFF
--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -144,6 +144,7 @@ DISCARD_BASKET_NAMES = {
     "api_key",  # Added from authenticated calls
     "api-key",  # Alternate spelling for authenticated calls
     "privacy",  # Common in newsletter forms as privacy policy checkbox
+    "trigger_welcome",  # "N" to avoid sending a (deprecated) welcome email.
 }
 
 

--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -142,6 +142,7 @@ DISCARD_BASKET_NAMES = {
     #
     "fxa_last_login",  # Imported into Acoustic periodically from FxA
     "api_key",  # Added from authenticated calls
+    "api-key",  # Alternate spelling for authenticated calls
     "privacy",  # Common in newsletter forms as privacy policy checkbox
 }
 

--- a/basket/news/tests/test_ctms.py
+++ b/basket/news/tests/test_ctms.py
@@ -535,6 +535,7 @@ class ToVendorTests(TestCase):
             "api_key": "a-basket-api-key",
             "api-key": "a_different_key",
             "privacy": True,
+            "trigger_welcome": "N",
         }
         prepared = to_vendor(data)
         assert prepared == {}

--- a/basket/news/tests/test_ctms.py
+++ b/basket/news/tests/test_ctms.py
@@ -533,6 +533,7 @@ class ToVendorTests(TestCase):
             "cv_last_active_date": "2021-04-11",
             "fxa_last_login": "2020-04-11",
             "api_key": "a-basket-api-key",
+            "api-key": "a_different_key",
             "privacy": True,
         }
         prepared = to_vendor(data)


### PR DESCRIPTION
Previously, `CTMSUnknownKeyError` was raised when the Basket update data had an unrecognized key. Instead, the code now collects these and uses ``sentry_sdk.capture_message`` to log it in Sentry but continue processing.

Two valid keys (`api-key` and `trigger_welcome`) that caused issues in production are now in the `DISCARD_BASKET_NAMES` set, and will be silently discarded.