### PR TITLE
Raise exceptions from CTMS backend, to enable retries in et_task

### DIFF
--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -800,11 +800,7 @@ class CTMS:
                 raise CTMSNotConfigured()
             else:
                 return None
-        try:
-            return self.interface.post_to_create(to_vendor(data))
-        except Exception:
-            sentry_sdk.capture_exception()
-            return None
+        return self.interface.post_to_create(to_vendor(data))
 
     def update(self, existing_data, update_data):
         """
@@ -823,12 +819,8 @@ class CTMS:
         if not email_id:
             # TODO: When CTMS is primary, this should be an error
             return None
-        try:
-            ctms_data = to_vendor(update_data, existing_data)
-            return self.interface.patch_by_email_id(email_id, ctms_data)
-        except Exception:
-            sentry_sdk.capture_exception()
-            return None
+        ctms_data = to_vendor(update_data, existing_data)
+        return self.interface.patch_by_email_id(email_id, ctms_data)
 
     def update_by_alt_id(self, alt_id_name, alt_id_value, update_data):
         """

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -231,7 +231,7 @@ def et_task(func):
             SilverpopResponseException,
         ) as e:
             # These could all be connection issues, so try again later.
-            # IOError covers URLError and SSLError.
+            # IOError covers URLError, SSLError, and requests.HTTPError.
             if ignore_error(e):
                 with sentry_sdk.push_scope() as scope:
                     scope.set_tag("action", "ignored")


### PR DESCRIPTION
This PR fixes issue #718.

Previously, exceptions would be captured in the ``CTMS`` class, reported to Sentry, and then ``None`` would be returned to the caller. Instead, let the exceptions be returned to the caller.

``requests`` raises exceptions derived from a shared base exception class ``RequestException``, which is derived from ``IOError``. This means that low-level exceptions such as timeouts and DNS lookup failures will be retried by ``et_task`` with no code changes. 

It also means HTTP Errors such as ``400 Bad Request`` and ``503 Service Unavailable`` will be retried. Some HTTP errors represent issues that will not be fixed by a Retry, so these are now raised as new exceptions, which will not be retried by ``et_task``:

* ``CTMSNotFoundByEmailIDError`` - Replaces a 404 when the ``{email_id}`` is part of the URL
* ``CTMSUniqueIDConflictError`` - Replaces a 409 error, signifying a primary ID conflict
* ``CTMSValidationError`` - Replaces a 422 error, signifying a schema validation error. This also fixes #713.

Most utility and task code did not need changes to propagate these exceptions. The two changes are:

* ``get_user_data`` - Remove the 404 exception, since the ``/ctms`` endpoint doesn't return a 404 on no match.Instead, handle the ``CTMSNotFoundByAltIDError`` exception by returning None, similar to the SFDC code.
* ``sfdc_add_update`` - Remove all the SFDC interface code (getting started on issue #719), and handle switching from add to and update when ``CTMSUniqueIDConflictError`` is raised.

