### PR TITLE
Expand PII field list for Sentry pre-scrubbing

### DIFF
--- a/basket/base/tests/test__utils.py
+++ b/basket/base/tests/test__utils.py
@@ -43,6 +43,7 @@ def test_pre_sentry_sanitisation__before_send_setup():
         "last_name",
         "mobile_number",
         "payee_id",
+        "primary_email",
         "remote_addr",
         "remoteaddresschain",
         "token",

--- a/basket/settings.py
+++ b/basket/settings.py
@@ -356,6 +356,7 @@ SENSITIVE_FIELDS_TO_MASK_ENTIRELY = [
     "last_name",
     "mobile_number",
     "payee_id",
+    "primary_email",
     "remote_addr",
     "remoteaddresschain",
     "token",


### PR DESCRIPTION
`primary_email` is already being scrubbed at the hosted Sentry side via in-app config, but better to stop it leaving our infra entirely.

Resolves #831 