### PR TITLE
feature(mirroring): Use github actions for mirroring

### DIFF
--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -1,0 +1,17 @@
+name: Mirror repo
+on: [push]
+
+jobs:
+  mirror:
+    if: github.repository == 'mozmeao/basket'
+    runs-on: ubuntu-latest
+    steps:
+       - name: mirror in gitlab
+         uses: actions/checkout@v3
+         with:
+          fetch-depth: 0
+       - uses: yesolutions/mirror-action@master
+         with:
+            REMOTE: 'https://gitlab.com/mozmeao/basket.git'
+            GIT_USERNAME: ${{ secrets.GITLAB_USERNAME }}
+            GIT_PASSWORD: ${{ secrets.GITLAB_PASSWORD }}


### PR DESCRIPTION
Since I do not have PR access to this repository this is from my fork. The workflow will not fire until this moves to a `push` so until it is merged.

