### PR TITLE
Fix #930: Mask email in user data requests

### DIFF
--- a/basket/news/tests/test__utils.py
+++ b/basket/news/tests/test__utils.py
@@ -18,6 +18,7 @@ from basket.news.utils import (
     has_valid_fxa_oauth,
     is_authorized,
     language_code_is_valid,
+    mask_email,
     parse_newsletters_csv,
     process_email,
 )
@@ -383,3 +384,10 @@ class TestProcessEmail(TestCase):
         self.assertIsNone(process_email("dude@home@example.com"))
         self.assertIsNone(process_email(""))
         self.assertIsNone(process_email(None))
+
+
+class TestMaskEmail(TestCase):
+    def test_mask(self):
+        self.assertEqual(mask_email("dude@example.com"), "d**e@e*****e.com")
+        self.assertEqual(mask_email("the.dude@example.com"), "t******e@e*****e.com")
+        self.assertEqual(mask_email("dude@sub.example.com"), "d**e@s*********e.com")

--- a/basket/news/urls.py
+++ b/basket/news/urls.py
@@ -22,7 +22,7 @@ urlpatterns = (
     path("common-voice-goals/", common_voice_goals),
     path("subscribe/", subscribe),
     path("unsubscribe/<uuid:token>/", unsubscribe),
-    path("user/<uuid:token>/", user),
+    path("user/<uuid:token>/", user, name="user"),
     path("user-meta/<uuid:token>/", user_meta),
     path("confirm/<uuid:token>/", confirm),
     path("debug-user/", debug_user),

--- a/basket/news/utils.py
+++ b/basket/news/utils.py
@@ -247,7 +247,7 @@ def get_user_data(
     fxa_id=None,
     extra_fields=None,
     get_fxa=False,
-    masked=False,
+    masked=True,
 ):
     """
     Return a dictionary of the user's data.
@@ -264,6 +264,9 @@ def get_user_data(
 
     If `get_fxa` is True then a boolean field will be including indicating whether they are
     an account holder or not.
+
+    When `masked` is True, we return masked emails. We should only set
+    `masked=False` when a valid API key is being used.
 
     Review of results:
 
@@ -344,7 +347,7 @@ def get_user_data(
     return user
 
 
-def get_user(token=None, email=None, get_fxa=False):
+def get_user(token=None, email=None, get_fxa=False, masked=True):
     if settings.MAINTENANCE_MODE and not settings.MAINTENANCE_READ_ONLY:
         # can't return user data during maintenance
         return HttpResponseJSON(
@@ -357,7 +360,7 @@ def get_user(token=None, email=None, get_fxa=False):
         )
 
     try:
-        user_data = get_user_data(token, email, get_fxa=get_fxa, masked=not email)
+        user_data = get_user_data(token, email, get_fxa=get_fxa, masked=masked)
         status_code = 200
     except NewsletterException as e:
         return newsletter_exception_response(e)

--- a/basket/news/views.py
+++ b/basket/news/views.py
@@ -657,7 +657,8 @@ def user(request, token):
         return update_user_task(request, SET, data)
 
     get_fxa = "fxa" in request.GET
-    return get_user(token, get_fxa=get_fxa)
+    masked = not has_valid_api_key(request)
+    return get_user(token, get_fxa=get_fxa, masked=masked)
 
 
 @require_POST
@@ -815,7 +816,8 @@ def lookup_user(request):
             400,
         )
 
-    if email and not is_authorized(request, email):
+    authorized = is_authorized(request, email)
+    if email and not authorized:
         return HttpResponseJSON(
             {
                 "status": "error",
@@ -833,7 +835,7 @@ def lookup_user(request):
 
     try:
         user_data = get_user_data(
-            token=token, email=email, get_fxa=get_fxa, masked=not email
+            token=token, email=email, get_fxa=get_fxa, masked=not authorized
         )
     except NewsletterException as e:
         return newsletter_exception_response(e)

--- a/basket/news/views.py
+++ b/basket/news/views.py
@@ -754,9 +754,9 @@ def newsletters(request):
 
 @never_cache
 def lookup_user(request):
-    """Lookup a user in Exact Target given email or token (not both).
+    """Lookup a user in CTMS given email or token (not both).
 
-    To look up by email, a valid API key are required.
+    To look up by email, a valid API key is required.
 
     If email and token are both provided, an error is returned rather
     than trying to define all the possible behaviors.
@@ -781,15 +781,14 @@ def lookup_user(request):
     or a request header ``X-api-key``. If it's provided as a query parameter,
     any request header is ignored.
 
-    For other errors, similarly
-    response status is 4xx and the json 'desc' says what's wrong.
+    For other errors, similarly response status is 4xx and the json 'desc'
+    says what's wrong.
 
     Otherwise, status is 200 and json is the return value from
     `get_user_data`. See that method for details.
 
-    Note that because this method always calls Exact Target one or
-    more times, it can be slower than some other Basket APIs, and will
-    fail if ET is down.
+    Note that because this method always calls CTMS one or more times, it can be
+    slower than some other Basket APIs, and will fail if CTMS is down.
     """
     if settings.MAINTENANCE_MODE and not settings.MAINTENANCE_READ_ONLY:
         # can't return user data during maintenance
@@ -833,7 +832,9 @@ def lookup_user(request):
             return invalid_email_response()
 
     try:
-        user_data = get_user_data(token=token, email=email, get_fxa=get_fxa)
+        user_data = get_user_data(
+            token=token, email=email, get_fxa=get_fxa, masked=not email
+        )
     except NewsletterException as e:
         return newsletter_exception_response(e)
 

--- a/docs/newsletter_api.rst
+++ b/docs/newsletter_api.rst
@@ -129,6 +129,8 @@ The following URLs are available (assuming "/news" is app url):
         } on error
         token-required
 
+    The email will be masked unless the request was made with a valid API key.
+
     If POSTed, this method updates the user's data with the supplied
     fields. Note that the user is only subscribed to "newsletters" after
     this, meaning the user will be unsubscribed to all other
@@ -201,8 +203,8 @@ The following URLs are available (assuming "/news" is app url):
     On success, response is a bunch of data about the user::
 
         {
-            'status':  'ok',      # no errors talking to ET
-            'status':  'error',   # errors talking to ET, see next field
+            'status':  'ok',      # no errors talking to CTMS
+            'status':  'error',   # errors talking to CTMS, see next field
             'desc':  'error message'   # details if status is error
             'email': 'email@address',
             'format': 'T'|'H',
@@ -216,8 +218,11 @@ The following URLs are available (assuming "/news" is app url):
             'master': True if we found them in the master subscribers table
         }
 
-    Note: Because this method always calls Exact Target one or more times, it
-    can be slower than some other Basket APIs, and will fail if ET is down.
+    The email will be masked unless the request was made with a valid API key.
+
+    Note: Because this method always calls the backing contact management system
+    one or more times, it can be slower than some other Basket APIs, and will
+    fail if it is down.
 
 /news/recover/
 --------------
@@ -235,7 +240,7 @@ The following URLs are available (assuming "/news" is app url):
     sent to the email, containing a link to the existing subscriptions page
     with their token in it, so they can use it to manage their subscriptions.
 
-    If the user is known in ET, the message will be sent in their preferred
+    If the user is known in CTMS, the message will be sent in their preferred
     language and format.
 
     If the email provided is not known, a 404 status is returned.


### PR DESCRIPTION
Mask emails for user data requests if no API key provided.