### PR TITLE
Flip the default of email masking

### DIFF
--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -612,7 +612,7 @@ def upsert_contact(api_call_type, data, user_data):
 
     if send_confirm and settings.SEND_CONFIRM_MESSAGES:
         send_confirm_message.delay(
-            user_data["email"],
+            data["email"],
             token,
             update_data.get("lang", user_data.get("lang", "en-US")),
             send_confirm,

--- a/basket/news/tests/test__utils.py
+++ b/basket/news/tests/test__utils.py
@@ -15,6 +15,7 @@ from basket.news.utils import (
     get_best_supported_lang,
     get_email_block_list,
     get_fxa_clients,
+    get_user_data,
     has_valid_fxa_oauth,
     is_authorized,
     language_code_is_valid,
@@ -391,3 +392,30 @@ class TestMaskEmail(TestCase):
         self.assertEqual(mask_email("dude@example.com"), "d**e@e*****e.com")
         self.assertEqual(mask_email("the.dude@example.com"), "t******e@e*****e.com")
         self.assertEqual(mask_email("dude@sub.example.com"), "d**e@s*********e.com")
+
+
+@patch("basket.news.utils.ctms", spec_set=["get"])
+class TestGetUserData(TestCase):
+    # TODO: Add more testing for `get_user_data` here.
+
+    def setUp(self):
+        self.email = "hisdudeness@example.com"
+
+    def test_no_kwarg_get_user_data(self, ctms_mock):
+        """
+        Test that the default kwarg for `masked` is `False.
+
+        When the default is true it can cause problems with requests to acoustic
+        since this method is used internally as well.
+        """
+        ctms_mock.get.return_value = {"email": self.email}
+        data = get_user_data(email=self.email)
+        self.assertEqual(data["email"], self.email)
+
+        data = get_user_data(email=self.email, masked=False)
+        self.assertEqual(data["email"], self.email)
+
+    def test_get_user_data_masked(self, ctms_mock):
+        ctms_mock.get.return_value = {"email": self.email}
+        data = get_user_data(email=self.email, masked=True)
+        self.assertEqual(data["email"], "h*********s@e*****e.com")

--- a/basket/news/utils.py
+++ b/basket/news/utils.py
@@ -247,7 +247,7 @@ def get_user_data(
     fxa_id=None,
     extra_fields=None,
     get_fxa=False,
-    masked=True,
+    masked=False,
 ):
     """
     Return a dictionary of the user's data.
@@ -266,7 +266,8 @@ def get_user_data(
     an account holder or not.
 
     When `masked` is True, we return masked emails. We should only set
-    `masked=False` when a valid API key is being used.
+    `masked=False` when a valid API key is being used. This defaults to False to
+    avoid problems with requests to acoustic.
 
     Review of results:
 


### PR DESCRIPTION
When deployed, this caused an issue since `get_user_data` is used internally and sends the output to acoustic, which was then masked. This update default to masking off and only masks in the views fetching user data.