### PR TITLE
Move pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,7 @@ known_django = 'django'
 known_first_party = 'basket'
 profile = 'black'
 sections = 'FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER'
+
+[tool.pytest.ini_options]
+addopts = "-ra --ignore=vendor"
+DJANGO_SETTINGS_MODULE = "basket.settings"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[tool:pytest]
-DJANGO_SETTINGS_MODULE=basket.settings
-addopts = --ignore=vendor
-
 [tool:paul-mclendahand]
 github_user=mozmeao
 github_project=basket


### PR DESCRIPTION
Docs explain:

Usage of setup.cfg is not recommended unless for very simple use cases. .cfg files use a different parser than pytest.ini and tox.ini which might cause hard to track down problems. When possible, it is recommended to use the latter files, or pyproject.toml, to hold your pytest configuration.