### PR TITLE
Use `hiredis://` scheme

### DIFF
--- a/basket/base/tests/test_settings.py
+++ b/basket/base/tests/test_settings.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+
+
+class TestSettings(TestCase):
+    @override_settings(REDIS_URL="redis://localhost:6379/0")
+    def test_hiredis(self):
+        """
+        Test that the hiredis parser is used when the REDIS_URL scheme is set to `hiredis://`.
+        """
+        from django.conf import settings
+
+        # Note: If this fails after upgrading to Django >= 4, it's because the `django_cache_url`
+        # switches to using the built-in Django `RedisCache`. This is a reminder to remove the
+        # `django_redis` dependency and update this test.
+        assert settings.CACHES["default"]["BACKEND"] == "django_redis.cache.RedisCache"
+        assert settings.CACHES["default"]["OPTIONS"]["PARSER_CLASS"] == "redis.connection.HiredisParser"

--- a/basket/settings.py
+++ b/basket/settings.py
@@ -49,9 +49,10 @@ BASKET_RW_URL = config(
 REDIS_URL = config("REDIS_URL", None)
 if REDIS_URL:
     REDIS_URL = REDIS_URL.rstrip("/0")
+    HIREDIS_URL = REDIS_URL.replace("redis://", "hiredis://")
     # use redis for celery and cache
     os.environ["CELERY_BROKER_URL"] = REDIS_URL + "/" + config("REDIS_CELERY_DB", "0")
-    os.environ["CACHE_URL"] = REDIS_URL + "/" + config("REDIS_CACHE_DB", "1")
+    os.environ["CACHE_URL"] = HIREDIS_URL + "/" + config("REDIS_CACHE_DB", "1")
 
 # Production uses MySQL, but Sqlite should be sufficient for local development.
 # Our CI server tests against MySQL.
@@ -80,10 +81,6 @@ CACHES = {
     },
     "product_details": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
 }
-
-if CACHES["default"]["BACKEND"].startswith("django_redis"):
-    options = CACHES["default"].setdefault("OPTIONS", {})
-    options["PARSER_CLASS"] = "redis.connection.HiredisParser"
 
 default_email_backend = "django.core.mail.backends.console.EmailBackend" if DEBUG else "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_BACKEND = config("EMAIL_BACKEND", default=default_email_backend)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,9 +71,11 @@ services:
       - CELERY_LOG_LEVEL=debug
       - DJANGO_LOG_LEVEL=DEBUG
       - URLWAIT_TIMEOUT=30
+      - REDIS_URL=redis://redis:6379
     env_file: docker/envfiles/test.env
     depends_on:
       - db
+      - redis
     command:
       ./bin/run-tests.sh
 
@@ -88,9 +90,11 @@ services:
       - CELERY_LOG_LEVEL=debug
       - DJANGO_LOG_LEVEL=DEBUG
       - URLWAIT_TIMEOUT=30
+      - REDIS_URL=redis://redis:6379
     env_file: docker/envfiles/test.env
     depends_on:
       - db
+      - redis
     command:
       ./bin/run-tests.sh
 


### PR DESCRIPTION
The `django_cache_url` lib is already handling the `PARSER_CLASS` change for us if we use the scheme. This also future proofs the code when Django >= 4 switches to using the built-in `RedisCache`, whereas the current code would have missed this due to the dotted path name change.