### PR TITLE
Ref #1012: investigate unknown data

### DIFF
--- a/basket/news/tests/test_ctms.py
+++ b/basket/news/tests/test_ctms.py
@@ -749,6 +749,38 @@ class ToVendorTests(TestCase):
             "newsletters": [{"name": "guardian-vpn-waitlist", "subscribed": True}]
         }
 
+    @patch(
+        "basket.news.backends.ctms.newsletter_slugs",
+        return_value=["guardian-vpn-waitlist"],
+    )
+    @patch(
+        "basket.news.backends.ctms.newsletter_waitlist_slugs",
+        return_value=["guardian-vpn-waitlist"],
+    )
+    @patch("basket.news.backends.ctms.sentry_sdk")
+    def test_no_unknown_data_for_standard_waitlist_subscribe(
+        self, mock_sentry, mock_wl_slugs, mock_nl_slugs
+    ):
+        """Reproduce mozmeao/basket#1012"""
+        data = {
+            "fpn_country": "ua",
+            "lang": "en",
+            "newsletters": ["guardian-vpn-waitlist"],
+            "source_url": "https://www.mozilla.org/ru/products/vpn/invite/",
+        }
+        prepared = to_vendor(data)
+        mock_sentry.capture_message.assert_not_called()
+        assert prepared == {
+            "waitlists": [
+                {
+                    "fields": {"geo": "ua"},
+                    "name": "vpn",
+                    "source": "https://www.mozilla.org/ru/products/vpn/invite/",
+                    "subscribed": True,
+                }
+            ]
+        }
+
 
 class CTMSSessionTests(TestCase):
     EXAMPLE_TOKEN = {


### PR DESCRIPTION
Ref #1012

This test seems to contain the same data as https://mozilla.sentry.io/issues/4087704376/?project=6260602&query=is%3Aunresolved&stream_index=0

<img width="804" alt="Screenshot 2023-06-08 at 11 16 57" src="https://github.com/mozmeao/basket/assets/546692/dd5ef469-4a04-4930-9362-0a149db08cdc">

but does not produce the same warning :(

```
ctms.to_vendor() could not convert unknown data

{
  unknown_data: {
    fpn_country: ua
  }
}
```