### PR TITLE
Remove unused PUT method on CTMS interface

### DIFF
--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -529,7 +529,6 @@ class CTMSSession:
     get = partialmethod(request, "GET")
     patch = partialmethod(request, "PATCH")
     post = partialmethod(request, "POST")
-    put = partialmethod(request, "PUT")
 
 
 class CTMSNoIdsError(CTMSError):
@@ -686,28 +685,6 @@ class CTMSInterface:
         resp = self.session.get(f"/ctms/{email_id}")
         self._check_response(resp, email_id)
         return resp.json()
-
-    @time_request
-    def put_by_email_id(self, email_id, data):
-        """
-        Call PUT /ctms/{email_id} to replace a CTMS contact by ID
-
-        @param email_id: The CTMS email_id of the contact
-        @param data: The new or updated contact data
-        @return: The created or replaced contact data
-        """
-        resp = self.session.put(f"/ctms/{email_id}", json=data)
-        self._check_response(resp, email_id)
-        return resp.json()
-
-    def put(self, data):
-        """
-        Call PUT /ctms/{email_id} to replace a CTMS contact, using email_id from data
-
-        @return: The created or replaced contact data
-        """
-        email_id = data["email"]["email_id"]
-        return self.put_by_email_id(email_id, data)
 
     @time_request
     def patch_by_email_id(self, email_id, data):

--- a/basket/news/tests/test_ctms.py
+++ b/basket/news/tests/test_ctms.py
@@ -1066,7 +1066,7 @@ class CTMSSessionTests(TestCase):
 def mock_interface(expected_call, status_code, response_data, reason=None):
     """Return a CTMSInterface with a mocked session and response"""
     call = expected_call.lower()
-    assert call in set(("patch", "post", "put", "get"))
+    assert call in set(("patch", "post", "get"))
     session = Mock(spec_set=[call])
     caller = getattr(session, call)
 


### PR DESCRIPTION
Goals

* Remove dead code
* Clarify which method does Basket use when submitting contact changes to CTMS
