### PR TITLE
Optimize metrics calls via tagging

### DIFF
--- a/basket/base/tests/test_decorator.py
+++ b/basket/base/tests/test_decorator.py
@@ -68,9 +68,4 @@ class TestDecorator:
         worker = get_worker()
         worker.work(burst=True)  # Burst = worker will quit after all jobs consumed.
 
-        assert len(metrics_mock.filter_records("incr")) == 2
-        metrics_mock.assert_incr_once("basket.base.tests.tasks.empty_job.success")
-        metrics_mock.assert_incr_once("news.tasks.success_total")
-        assert len(metrics_mock.filter_records("timing")) == 2
-        metrics_mock.assert_timing_once("basket.base.tests.tasks.empty_job.duration")
-        metrics_mock.assert_timing_once("news.tasks.duration_total")
+        metrics_mock.assert_timing_once("task.timings", tags=["task:basket.base.tests.tasks.empty_job", "status:success"])

--- a/basket/base/tests/test_middleware.py
+++ b/basket/base/tests/test_middleware.py
@@ -19,28 +19,20 @@ class TestMetricsMiddleware:
     def test_200(self, metrics_mock):
         resp = Client().get(reverse("watchman.ping"))
         assert resp.status_code == 200
-        metrics_mock.assert_incr_once("response.200")
-        metrics_mock.assert_timing_once("view.watchman.views.ping.GET", tags=["status_code:200"])
-        metrics_mock.assert_timing_once("view.watchman.views.GET", tags=["status_code:200"])
-        metrics_mock.assert_timing_once("view.GET", tags=["status_code:200"])
-        metrics_mock.assert_incr_once("view.count.watchman.views.ping.GET")
-        metrics_mock.assert_incr_once("view.count.watchman.views.GET")
-        metrics_mock.assert_incr_once("view.count.GET")
+        metrics_mock.assert_timing_once(
+            "view.timings", tags=["view_path:watchman.views.ping.GET", "module:watchman.views.GET", "method:GET", "status_code:200"]
+        )
 
     def test_404(self, metrics_mock):
         resp = Client().get("/404/")
         assert resp.status_code == 404
-        metrics_mock.assert_incr_once("response.404")
         # We don't time 404 responses.
         assert not metrics_mock.filter_records("timing")
 
     def test_500(self, metrics_mock):
         resp = Client().get("/500/")
         assert resp.status_code == 500
-        metrics_mock.assert_incr_once("response.500")
-        metrics_mock.assert_timing_once("view.django.views.defaults.server_error.GET", tags=["status_code:500"])
-        metrics_mock.assert_timing_once("view.django.views.defaults.GET", tags=["status_code:500"])
-        metrics_mock.assert_timing_once("view.GET", tags=["status_code:500"])
-        metrics_mock.assert_incr_once("view.count.django.views.defaults.server_error.GET")
-        metrics_mock.assert_incr_once("view.count.django.views.defaults.GET")
-        metrics_mock.assert_incr_once("view.count.GET")
+        metrics_mock.assert_timing_once(
+            "view.timings",
+            tags=["view_path:django.views.defaults.server_error.GET", "module:django.views.defaults.GET", "method:GET", "status_code:500"],
+        )

--- a/basket/news/backends/common.py
+++ b/basket/news/backends/common.py
@@ -40,10 +40,7 @@ def get_timer_decorator(prefix):
 
             def record_timing():
                 totaltime = int((time() - starttime) * 1000)
-                metrics.timing(f"{prefix}.timing", totaltime)
-                metrics.timing(f"{prefix}.{f.__name__}.timing", totaltime)
-                metrics.incr(f"{prefix}.count")
-                metrics.incr(f"{prefix}.{f.__name__}.count")
+                metrics.timing(f"{prefix}.timing", totaltime, tags=[f"fn:{f.__name__}"])
 
             try:
                 resp = f(*args, **kwargs)

--- a/basket/news/backends/ctms.py
+++ b/basket/news/backends/ctms.py
@@ -514,16 +514,12 @@ class CTMSSession:
         session = self._session
         url = urljoin(self.api_url, path)
         resp = session.request(method, url, *args, **kwargs)
-        metrics.incr("news.backends.ctms.request")
-        metrics.incr(f"news.backends.ctms.request.{method}")
-        metrics.incr(f"news.backends.ctms.response.{resp.status_code}")
+        metrics.incr("news.backends.ctms.request", tags=[f"method:{method}", f"status_code:{resp.status_code}"])
         if resp.status_code == 401:
             self._session = self._authorize_session(session)
             metrics.incr("news.backends.ctms.session_refresh")
             resp = session.request(method, url, *args, **kwargs)
-            metrics.incr("news.backends.ctms.request")
-            metrics.incr(f"news.backends.ctms.request.{method}")
-            metrics.incr(f"news.backends.ctms.response.{resp.status_code}")
+            metrics.incr("news.backends.ctms.request", tags=[f"method:{method}", f"status_code:{resp.status_code}"])
         return resp
 
     get = partialmethod(request, "GET")

--- a/basket/news/tests/__init__.py
+++ b/basket/news/tests/__init__.py
@@ -1,1 +1,14 @@
+import functools
+
+from markus.testing import MetricsMock
+
 default_app_config = "basket.news.apps.BasketNewsConfig"
+
+
+def mock_metrics(f):
+    @functools.wraps(f)
+    def wrapper(self, *args, **kwargs):
+        with MetricsMock() as mm:
+            return f(self, mm, *args, **kwargs)
+
+    return wrapper

--- a/basket/settings.py
+++ b/basket/settings.py
@@ -152,8 +152,7 @@ MIDDLEWARE = (
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
-    "basket.base.middleware.MetricsStatusMiddleware",
-    "basket.base.middleware.MetricsRequestTimingMiddleware",
+    "basket.base.middleware.MetricsViewTimingMiddleware",
     "ratelimit.middleware.RatelimitMiddleware",
 )
 


### PR DESCRIPTION
Using tags to add data and letting the metric name be less specific. With this approach we can select the metric and group by the tags to show charts in Grafana.

A nice example from socorro:
https://earthangel-b40313e5.influxcloud.net/d/LysVjx8Zk/socorro-prod-megamaster-remix?orgId=1&refresh=1m&from=now-6h&to=now&viewPanel=100