### PR TITLE
Add --max-jobs to rqworker

### DIFF
--- a/basket/base/management/commands/rqworker.py
+++ b/basket/base/management/commands/rqworker.py
@@ -23,11 +23,19 @@ class Command(BaseCommand):
             default=False,
             help="Run worker with scheduler enabled. Default: False",
         )
+        parser.add_argument(
+            "--max-jobs",
+            dest="max_jobs",
+            default=None,
+            type=int,
+            help="Maximum number of jobs to execute before quitting. Default: None (infinite)",
+        )
 
     def handle(self, *args, **options):
         kwargs = {
             "burst": options.get("burst", False),
             "with_scheduler": options.get("with_scheduler", False),
+            "max_jobs": options.get("max_jobs", None),
         }
         try:
             worker = get_worker()

--- a/bin/run-worker.sh
+++ b/bin/run-worker.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -ex
 
 NEW_RELIC_CONFIG_FILE=newrelic.ini newrelic-admin run-program \
-python manage.py rqworker --with-scheduler
+python manage.py rqworker --max-jobs "${RQ_MAX_JOBS:-5000}" --with-scheduler

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
   worker:
     image: mozmeao/basket:${GIT_COMMIT_SHORT:-latest}
     platform: linux/amd64
+    restart: unless-stopped
     volumes:
       - .:/app
     env_file:

--- a/docker/envfiles/local.env
+++ b/docker/envfiles/local.env
@@ -5,3 +5,5 @@ DJANGO_LOG_LEVEL=DEBUG
 LOCAL_DEV=True
 REDIS_URL=redis://redis:6379
 URLWAIT_TIMEOUT=30
+# Setting max_jobs low to test worker completion and restarts via Docker compose.
+RQ_MAX_JOBS=5


### PR DESCRIPTION
This is so we can cycle the worker pods every so often.