### PR TITLE
Move email confirmation sending to a task for retries

### DIFF
--- a/basket/petition/tasks.py
+++ b/basket/petition/tasks.py
@@ -1,0 +1,20 @@
+from django.core.mail import send_mail
+from django.template.loader import render_to_string
+
+from basket.base.decorators import rq_task
+
+
+@rq_task
+def send_email_confirmation(name, email, confirm_link):
+    email_subject = "Verify your email: Joint Statement on AI Safety and Openness"
+    email_body = render_to_string(
+        "petition/confirmation_email.txt",
+        {
+            "name": name,
+            "confirm_link": confirm_link,
+        },
+    )
+    email_from = "Mozilla <noreply@mozilla.com>"
+    email_to = [f"{name} <{email}>"]
+
+    send_mail(email_subject, email_body, email_from, email_to)


### PR DESCRIPTION
We are getting many SMTP authentication errors, even when the auth is correct, so the task will retry these.