### PR TITLE
Move settings to use django-configurations

### DIFF
--- a/basket/base/tests/test__utils.py
+++ b/basket/base/tests/test__utils.py
@@ -4,11 +4,7 @@ import json
 from django.test.utils import override_settings
 
 from basket.base.utils import email_is_testing
-from basket.settings import (
-    SENSITIVE_FIELDS_TO_MASK_ENTIRELY,
-    SENSITIVE_FIELDS_TO_MASK_PARTIALLY,
-    before_send,
-)
+from basket.settings import SentryConfigurationMixin
 
 
 @override_settings(TESTING_EMAIL_DOMAINS=["restmail.net"], USE_SANDBOX_BACKEND=False)
@@ -25,14 +21,14 @@ def test_pre_sentry_sanitisation__before_send_setup():
     # but we can at least confirm the source is set up how we expect
 
     # Sense check that we're passing in the params
-    _func_source = inspect.getsource(before_send)
+    _func_source = inspect.getsource(SentryConfigurationMixin.before_send)
     assert "with_default_keys=True,\n" in _func_source
-    assert "sensitive_keys=SENSITIVE_FIELDS_TO_MASK_ENTIRELY,\n" in _func_source
-    assert "# partial_keys=SENSITIVE_FIELDS_TO_MASK_PARTIALLY,\n" in _func_source
+    assert "sensitive_keys=cls.SENSITIVE_FIELDS_TO_MASK_ENTIRELY,\n" in _func_source
+    assert "# partial_keys=cls.SENSITIVE_FIELDS_TO_MASK_PARTIALLY,\n" in _func_source
     assert "# mask_position=POSITION.LEFT," in _func_source
     assert "# off_set=3" in _func_source
 
-    assert SENSITIVE_FIELDS_TO_MASK_ENTIRELY == [
+    assert SentryConfigurationMixin.SENSITIVE_FIELDS_TO_MASK_ENTIRELY == [
         "amo_id",
         "custom_id",
         "email",
@@ -51,8 +47,6 @@ def test_pre_sentry_sanitisation__before_send_setup():
         "user",
         "x-forwarded-for",
     ]
-
-    assert SENSITIVE_FIELDS_TO_MASK_PARTIALLY == []
 
 
 example_unsanitised_data = {
@@ -161,7 +155,7 @@ def test_pre_sentry_sanitisation(shared_datadir):
 
     assert "blocklist" in stringified
 
-    output = before_send(
+    output = SentryConfigurationMixin.before_send(
         event=input_event,
         hint=noop_because_hint_is_not_used,
     )

--- a/basket/base/tests/test_middleware.py
+++ b/basket/base/tests/test_middleware.py
@@ -2,6 +2,8 @@ from django.test import Client
 from django.test.utils import override_settings
 from django.urls import reverse
 
+import pytest
+
 
 class TestHostnameMiddleware:
     @override_settings(CLUSTER_NAME="us-west", K8S_NAMESPACE="prod", K8S_POD_NAME="pod1")
@@ -16,23 +18,29 @@ class TestHostnameMiddleware:
 
 
 class TestMetricsMiddleware:
+    @pytest.mark.urls("basket.base.tests.urls")
     def test_200(self, metrics_mock):
-        resp = Client().get(reverse("watchman.ping"))
+        resp = Client().get("/returns_200/")
         assert resp.status_code == 200
         metrics_mock.assert_timing_once(
-            "view.timings", tags=["view_path:watchman.views.ping.GET", "module:watchman.views.GET", "method:GET", "status_code:200"]
+            "view.timings",
+            tags=["view_path:basket.base.tests.urls.returns_200.GET", "module:basket.base.tests.urls.GET", "method:GET", "status_code:200"],
         )
 
+    @pytest.mark.urls("basket.base.tests.urls")
     def test_404(self, metrics_mock):
-        resp = Client().get("/404/")
+        resp = Client().get("/raises_404/")
         assert resp.status_code == 404
-        # We don't time 404 responses.
-        assert not metrics_mock.filter_records("timing")
+        metrics_mock.assert_timing_once(
+            "view.timings",
+            tags=["view_path:basket.base.tests.urls.raises_404.GET", "module:basket.base.tests.urls.GET", "method:GET", "status_code:404"],
+        )
 
+    @pytest.mark.urls("basket.base.tests.urls")
     def test_500(self, metrics_mock):
-        resp = Client().get("/500/")
+        resp = Client().get("/returns_500/")
         assert resp.status_code == 500
         metrics_mock.assert_timing_once(
             "view.timings",
-            tags=["view_path:django.views.defaults.server_error.GET", "module:django.views.defaults.GET", "method:GET", "status_code:500"],
+            tags=["view_path:basket.base.tests.urls.returns_500.GET", "module:basket.base.tests.urls.GET", "method:GET", "status_code:500"],
         )

--- a/basket/base/tests/urls.py
+++ b/basket/base/tests/urls.py
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django.http import Http404, HttpResponse
+from django.urls import path
+
+
+def returns_200(request):
+    return HttpResponse("test")
+
+
+def returns_404(request):
+    return HttpResponse("404", status=404)
+
+
+def raises_404(request):
+    raise Http404
+
+
+def returns_500(request):
+    return HttpResponse("500", status=500)
+
+
+urlpatterns = [
+    path("returns_200/", returns_200, name="returns_200"),
+    path("raises_404/", raises_404, name="raises_404"),
+    path("returns_404/", returns_404, name="returns_404"),
+    path("returns_500/", returns_500, name="returns_500"),
+]

--- a/basket/settings.py
+++ b/basket/settings.py
@@ -1,335 +1,408 @@
 import os
 import platform
 import re
-import socket
-import struct
-import sys
+from functools import partialmethod
 from pathlib import Path
 
-import dj_database_url
-import django_cache_url
 import markus
 import sentry_sdk
-from decouple import Csv, UndefinedValueError, config
+from configurations import Configuration, values
 from sentry_processor import DesensitizationProcessor
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.integrations.redis import RedisIntegration
 from sentry_sdk.integrations.rq import RqIntegration
 
-# Application version.
-VERSION = (0, 1)
-
 # ROOT path of the project. A pathlib.Path object.
 ROOT_PATH = Path(__file__).resolve().parents[1]
-ROOT = str(ROOT_PATH)
+
+
+# Set the default value of `environ_prefix` to `None` so that we can use `environ_name` without a prefix.
+values.Value.__init__ = partialmethod(values.Value.__init__, environ_prefix=None)
 
 
 def path(*args):
     return str(ROOT_PATH.joinpath(*args))
 
 
-LOCAL_DEV = config("LOCAL_DEV", False, cast=bool)
-DEBUG = config("DEBUG", default=False, cast=bool)
-UNITTEST = config("UNITTEST", default=False, cast=bool)
+class SentryConfigurationMixin:
+    # Data scrubbing before Sentry
+    # https://github.com/laiyongtao/sentry-processor
+    SENSITIVE_FIELDS_TO_MASK_ENTIRELY = [
+        "amo_id",
+        "custom_id",
+        "email",
+        "first_name",
+        "fxa_id",
+        "id",
+        "ip_address",
+        "last_name",
+        "mobile_number",
+        "payee_id",
+        "primary_email",
+        "remote_addr",
+        "remoteaddresschain",
+        "token",
+        "uid",
+        "user",
+        "x-forwarded-for",
+    ]
+    SENTRY_IGNORE_ERRORS = (
+        BrokenPipeError,
+        ConnectionResetError,
+    )
 
-# If we forget to set a `UNITTEST` env var by are running `pytest`, set it.
-if sys.argv[0].endswith(("py.test", "pytest")):
-    UNITTEST = True
+    @classmethod
+    def before_send(cls, event, hint):
+        if hint and "exc_info" in hint:
+            exc_type, exc_value, tb = hint["exc_info"]
+            if isinstance(exc_value, cls.SENTRY_IGNORE_ERRORS):
+                return None
 
-ADMINS = (
-    # ('Your Name', 'your_email@domain.com'),
-)
+        processor = DesensitizationProcessor(
+            with_default_keys=True,
+            sensitive_keys=cls.SENSITIVE_FIELDS_TO_MASK_ENTIRELY,
+            # partial_keys=cls.SENSITIVE_FIELDS_TO_MASK_PARTIALLY,
+            # mask_position=POSITION.LEFT,  # import from sentry_processor if you need it
+            # off_set=3,
+        )
+        event = processor.process(event, hint)
+        return event
 
-MANAGERS = ADMINS
-# avoids a warning from django
-TEST_RUNNER = "django.test.runner.DiscoverRunner"
+    @classmethod
+    def post_setup(cls):
+        """Sentry initialization"""
+        super().post_setup()
 
-# Production uses MySQL, but Sqlite should be sufficient for local development.
-# Our CI server tests against MySQL.
-DATABASES = {
-    "default": config(
-        "DATABASE_URL",
-        default="sqlite:///basket.db",
-        cast=dj_database_url.parse,
-    ),
-}
-if DATABASES["default"]["ENGINE"] == "django.db.backends.mysql":
-    DATABASES["default"]["OPTIONS"] = {
-        "init_command": "SET sql_mode='STRICT_TRANS_TABLES'",
-    }
-DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+        # DisallowedHost gets a lot of action thanks to scans/bots/scripts,
+        # but we need not take any action because it's already HTTP 400-ed.
+        # Note that we ignore at the Sentry client level
+        ignore_logger("django.security.DisallowedHost")
 
-# CACHE_URL and RQ_URL are derived from REDIS_URL.
-REDIS_URL = config("REDIS_URL", None)
-if REDIS_URL:
-    REDIS_URL = REDIS_URL.rstrip("/0")
-    # Use Redis for cache and rq.
-    # Note: We save the URL in the environment so `config` can pull from it below.
-    os.environ["CACHE_URL"] = f'{REDIS_URL}/{config("REDIS_CACHE_DB", "1")}'
-    RQ_URL = f'{REDIS_URL}/{config("REDIS_RQ_DB", "2")}'
+        sentry_sdk.init(
+            dsn=values.Value("", environ_name="SENTRY_DSN"),
+            release=values.Value("", environ_name="GIT_SHA"),
+            server_name=".".join(x for x in [cls.K8S_NAMESPACE, cls.CLUSTER_NAME, cls.HOSTNAME] if x),
+            integrations=[DjangoIntegration(signals_spans=False), RedisIntegration(), RqIntegration()],
+            before_send=cls.before_send,
+        )
 
-CACHES = {
-    "default": config("CACHE_URL", default="locmem://", cast=django_cache_url.parse),
-    "bad_message_ids": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "TIMEOUT": 12 * 60 * 60,  # 12 hours
-    },
-    "email_block_list": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "TIMEOUT": 60 * 60,  # 1 hour
-    },
-    "product_details": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
-}
 
-default_email_backend = "django.core.mail.backends.console.EmailBackend" if DEBUG else "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_BACKEND = config("EMAIL_BACKEND", default=default_email_backend)
-EMAIL_HOST = config("EMAIL_HOST", default="localhost")
-EMAIL_PORT = config("EMAIL_PORT", default=25, cast=int)
-EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False, cast=bool)
-EMAIL_SUBJECT_PREFIX = config("EMAIL_SUBJECT_PREFIX", default="[basket] ")
-EMAIL_HOST_USER = config("EMAIL_HOST_USER", default="")
-EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD", default="")
+class Base(Configuration):
+    ADMINS = (
+        # ('Your Name', 'your_email@domain.com'),
+    )
+    MANAGERS = ADMINS
 
-ALLOWED_HOSTS = config(
-    "ALLOWED_HOSTS",
-    default=".allizom.org, .moz.works, basket.mozmar.org, basket.mozilla.com, basket.mozilla.org",
-    cast=Csv(),
-)
-ALLOWED_CIDR_NETS = config("ALLOWED_CIDR_NETS", default="", cast=Csv())
-USE_X_FORWARDED_HOST = True
+    SECRET_KEY = values.SecretValue(environ_name="SECRET_KEY")
 
-SESSION_COOKIE_SECURE = config("SESSION_COOKIE_SECURE", not DEBUG, cast=bool)
-SESSION_ENGINE = config(
-    "SESSION_ENGINE",
-    default="django.contrib.sessions.backends.cache",
-)
-CSRF_COOKIE_SECURE = config("CSRF_COOKIE_SECURE", not DEBUG, cast=bool)
+    # Default to sqlite for local development.
+    DATABASES = values.DatabaseURLValue("sqlite:///basket.db", environ=False)
+    DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
-TIME_ZONE = "UTC"
-USE_TZ = True
-SITE_ID = 1
-USE_I18N = False
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
-SITE_URL = config("SITE_URL", default="https://basket.mozilla.org")
+    # CACHE_URL and RQ_URL are derived from REDIS_URL.
+    REDIS_URL = values.Value(None, environ_name="REDIS_URL")
+    if REDIS_URL:
+        # Strip the Redis database number from the end of the URL.
+        REDIS_URL = REDIS_URL.rstrip("/0")
+        REDIS_CACHE_DB = values.IntegerValue(1, environ_name="REDIS_CACHE_DB")
+        REDIS_RQ_DB = values.IntegerValue(2, environ_name="REDIS_RQ_DB")
+        # Use Redis for cache and rq.
+        # Note: We save the URL in the environment so it can be used below.
+        os.environ["CACHE_URL"] = f"{REDIS_URL}/{REDIS_CACHE_DB}"
+        RQ_URL = f"{REDIS_URL}/{REDIS_RQ_DB}"
 
-STATIC_ROOT = path("static")
-STATIC_URL = "/static/"
-if not DEBUG:
-    STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+    CACHES = values.CacheURLValue("locmem://").value
+    CACHES.update(
+        {
+            "bad_message_ids": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                "TIMEOUT": 12 * 60 * 60,  # 12 hours
+            },
+            "email_block_list": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                "TIMEOUT": 60 * 60,  # 1 hour
+            },
+            "product_details": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+        }
+    )
+    SITE_URL = values.Value("https://basket.mozilla.org", environ_name="SITE_URL")
+    STATIC_ROOT = path("static")
+    STATIC_URL = "/static/"
 
-try:
-    # Make this unique, and don't share it with anybody.
-    SECRET_KEY = config("SECRET_KEY")
-except UndefinedValueError as exc:
-    raise UndefinedValueError(
-        "The SECRET_KEY environment variable is required. Move env-dist to .env if you want the defaults.",
-    ) from exc
+    TIME_ZONE = "UTC"
+    USE_TZ = True
+    SITE_ID = 1
+    USE_I18N = False
 
-TEMPLATES = [
-    {
-        "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": ["templates"],
-        "APP_DIRS": True,
-        "OPTIONS": {
-            "context_processors": [
-                "django.contrib.auth.context_processors.auth",
-                "django.template.context_processors.request",
-                "django.contrib.messages.context_processors.messages",
-                "basket.news.context_processors.settings",
-            ],
+    HOSTNAME = platform.node()
+    CLUSTER_NAME = values.Value("", environ_name="CLUSTER_NAME")
+    K8S_NAMESPACE = values.Value("", environ_name="K8S_NAMESPACE")
+    K8S_POD_NAME = values.Value("", environ_name="K8S_POD_NAME")
+
+    INSTALLED_APPS = (
+        "basket.base",
+        "basket.news",
+        "basket.petition",
+        "corsheaders",
+        "product_details",
+        "django_extensions",
+        "mozilla_django_oidc",
+        "watchman",
+        "django.contrib.auth",
+        "django.contrib.contenttypes",
+        "django.contrib.sessions",
+        "django.contrib.sites",
+        "django.contrib.messages",
+        "django.contrib.admin",
+        "django.contrib.staticfiles",
+    )
+    LOGGING = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "root": {
+            "level": values.Value("WARNING", environ_name="DJANGO_LOG_LEVEL"),
+            "handlers": ["console"],
         },
-    },
-]
-
-MIDDLEWARE = (
-    "allow_cidr.middleware.AllowCIDRMiddleware",
-    "django.middleware.security.SecurityMiddleware",
-    "whitenoise.middleware.WhiteNoiseMiddleware",
-    "basket.base.middleware.HostnameMiddleware",
-    "django.middleware.common.CommonMiddleware",
-    "corsheaders.middleware.CorsMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
-    "basket.base.middleware.MetricsViewTimingMiddleware",
-    "ratelimit.middleware.RatelimitMiddleware",
-)
-
-ROOT_URLCONF = "basket.urls"
-
-INSTALLED_APPS = (
-    "basket.base",
-    "basket.news",
-    "basket.petition",
-    "corsheaders",
-    "product_details",
-    "django_extensions",
-    "mozilla_django_oidc",
-    "watchman",
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
-    "django.contrib.sessions",
-    "django.contrib.sites",
-    "django.contrib.messages",
-    "django.contrib.admin",
-    "django.contrib.staticfiles",
-)
-
-# SecurityMiddleware settings
-SECURE_HSTS_SECONDS = config("SECURE_HSTS_SECONDS", default="0", cast=int)
-SECURE_HSTS_INCLUDE_SUBDOMAINS = False
-SECURE_BROWSER_XSS_FILTER = config("SECURE_BROWSER_XSS_FILTER", default=True, cast=bool)
-SECURE_CONTENT_TYPE_NOSNIFF = config(
-    "SECURE_CONTENT_TYPE_NOSNIFF",
-    default=True,
-    cast=bool,
-)
-SECURE_SSL_REDIRECT = config("SECURE_SSL_REDIRECT", default=False, cast=bool)
-SECURE_REDIRECT_EXEMPT = [
-    r"^healthz/$",
-    r"^readiness/$",
-]
-if config("USE_SECURE_PROXY_HEADER", default=SECURE_SSL_REDIRECT, cast=bool):
-    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-
-# watchman
-WATCHMAN_DISABLE_APM = True
-WATCHMAN_CHECKS = (
-    "watchman.checks.caches",
-    "watchman.checks.databases",
-)
-
-
-ACOUSTIC_CLIENT_ID = config("ACOUSTIC_CLIENT_ID", None)
-ACOUSTIC_CLIENT_SECRET = config("ACOUSTIC_CLIENT_SECRET", None)
-ACOUSTIC_REFRESH_TOKEN = config("ACOUSTIC_REFRESH_TOKEN", None)
-ACOUSTIC_SERVER_NUMBER = config("ACOUSTIC_SERVER_NUMBER", None)
-ACOUSTIC_FXA_TABLE_ID = config("ACOUSTIC_FXA_TABLE_ID", None)
-ACOUSTIC_FXA_LOG_ENABLED = config("ACOUSTIC_FXA_LOG_ENABLED", True, cast=bool)
-
-ACOUSTIC_TX_CLIENT_ID = config("ACOUSTIC_TX_CLIENT_ID", None)
-ACOUSTIC_TX_CLIENT_SECRET = config("ACOUSTIC_TX_CLIENT_SECRET", None)
-ACOUSTIC_TX_REFRESH_TOKEN = config("ACOUSTIC_TX_REFRESH_TOKEN", None)
-ACOUSTIC_TX_SERVER_NUMBER = config("ACOUSTIC_TX_SERVER_NUMBER", None)
-# Send confirmation messages via Acoustic Transact
-SEND_CONFIRM_MESSAGES = config("SEND_CONFIRM_MESSAGES", False, cast=bool)
-
-# Mozilla CTMS
-CTMS_ENV = config("CTMS_ENV", "").lower()
-CTMS_ENABLED = config("CTMS_ENABLED", False, cast=bool)
-if CTMS_ENV == "stage":
-    default_url = "https://ctms.stage.mozilla-ess.mozit.cloud"
-elif CTMS_ENV == "prod":
-    default_url = "https://ctms.prod.mozilla-ess.mozit.cloud"
-else:
-    default_url = ""
-CTMS_URL = config("CTMS_URL", default_url)
-CTMS_CLIENT_ID = config("CTMS_CLIENT_ID", None)
-CTMS_CLIENT_SECRET = config("CTMS_CLIENT_SECRET", None)
-
-CORS_ORIGIN_ALLOW_ALL = True
-CORS_URLS_REGEX = r"^/(news/|subscribe)"
-
-# view rate limiting
-RATELIMIT_VIEW = "basket.news.views.ratelimited"
-
-# RQ configuration.
-RQ_RESULT_TTL = config("RQ_RESULT_TTL", default=0, cast=int)  # Ignore results.
-RQ_MAX_RETRY_DELAY = config("RQ_MAX_RETRY_DELAY", default=34 * 60 * 60, cast=int)  # 34 hours in seconds.
-RQ_MAX_RETRIES = 0 if UNITTEST else config("RQ_MAX_RETRIES", default=12, cast=int)
-RQ_EXCEPTION_HANDLERS = ["basket.base.rq.store_task_exception_handler"]
-RQ_IS_ASYNC = False if UNITTEST else config("RQ_IS_ASYNC", default=True, cast=bool)
-
-SNITCH_ID = config("SNITCH_ID", None)
-
-
-# via http://stackoverflow.com/a/6556951/107114
-def get_default_gateway_linux():
-    """Read the default gateway directly from /proc."""
-    try:
-        with open("/proc/net/route") as fh:
-            for line in fh:
-                fields = line.strip().split()
-                if fields[1] != "00000000" or not int(fields[3], 16) & 2:
-                    continue
-
-                return socket.inet_ntoa(struct.pack("<L", int(fields[2], 16)))
-    except OSError:
-        return "localhost"
-
-
-HOSTNAME = platform.node()
-CLUSTER_NAME = config("CLUSTER_NAME", default=None)
-K8S_NAMESPACE = config("K8S_NAMESPACE", default=None)
-K8S_POD_NAME = config("K8S_POD_NAME", default=None)
-
-# Data scrubbing before Sentry
-# https://github.com/laiyongtao/sentry-processor
-SENSITIVE_FIELDS_TO_MASK_ENTIRELY = [
-    "amo_id",
-    "custom_id",
-    "email",
-    "first_name",
-    "fxa_id",
-    "id",
-    "ip_address",
-    "last_name",
-    "mobile_number",
-    "payee_id",
-    "primary_email",
-    "remote_addr",
-    "remoteaddresschain",
-    "token",
-    "uid",
-    "user",
-    "x-forwarded-for",
-]
-
-SENSITIVE_FIELDS_TO_MASK_PARTIALLY = []
-
-SENTRY_IGNORE_ERRORS = (
-    BrokenPipeError,
-    ConnectionResetError,
-)
-
-
-def before_send(event, hint):
-    if hint and "exc_info" in hint:
-        exc_type, exc_value, tb = hint["exc_info"]
-        if isinstance(exc_value, SENTRY_IGNORE_ERRORS):
-            return None
-
-    processor = DesensitizationProcessor(
-        with_default_keys=True,
-        sensitive_keys=SENSITIVE_FIELDS_TO_MASK_ENTIRELY,
-        # partial_keys=SENSITIVE_FIELDS_TO_MASK_PARTIALLY,
-        # mask_position=POSITION.LEFT,  # import from sentry_processor if you need it
-        # off_set=3,
+        "formatters": {
+            "verbose": {"format": "%(levelname)s %(asctime)s %(module)s %(message)s"},
+        },
+        "handlers": {
+            "console": {
+                "level": "DEBUG",
+                "class": "logging.StreamHandler",
+                "formatter": "verbose",
+            },
+            "null": {"class": "logging.NullHandler"},
+        },
+        "loggers": {
+            "django.db.backends": {
+                "level": "ERROR",
+                "handlers": ["console"],
+                "propagate": False,
+            },
+            "suds.client": {"level": "ERROR", "handlers": ["console"], "propagate": False},
+        },
+    }
+    MIDDLEWARE = (
+        "allow_cidr.middleware.AllowCIDRMiddleware",
+        "django.middleware.security.SecurityMiddleware",
+        "whitenoise.middleware.WhiteNoiseMiddleware",
+        "basket.base.middleware.HostnameMiddleware",
+        "django.middleware.common.CommonMiddleware",
+        "corsheaders.middleware.CorsMiddleware",
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "django.middleware.csrf.CsrfViewMiddleware",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "django.contrib.messages.middleware.MessageMiddleware",
+        "basket.base.middleware.MetricsViewTimingMiddleware",
+        "ratelimit.middleware.RatelimitMiddleware",
     )
-    event = processor.process(event, hint)
-    return event
+    ROOT_URLCONF = "basket.urls"
+    TEMPLATES = [
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "DIRS": ["templates"],
+            "APP_DIRS": True,
+            "OPTIONS": {
+                "context_processors": [
+                    "django.contrib.auth.context_processors.auth",
+                    "django.template.context_processors.request",
+                    "django.contrib.messages.context_processors.messages",
+                    "basket.news.context_processors.settings",
+                ],
+            },
+        },
+    ]
 
+    ACOUSTIC_CLIENT_ID = values.Value(None, environ_name="ACOUSTIC_CLIENT_ID")
+    ACOUSTIC_CLIENT_SECRET = values.Value(None, environ_name="ACOUSTIC_CLIENT_SECRET")
+    ACOUSTIC_REFRESH_TOKEN = values.Value(None, environ_name="ACOUSTIC_REFRESH_TOKEN")
+    ACOUSTIC_SERVER_NUMBER = values.Value(None, environ_name="ACOUSTIC_SERVER_NUMBER")
+    ACOUSTIC_FXA_TABLE_ID = values.Value(None, environ_name="ACOUSTIC_FXA_TABLE_ID")
+    ACOUSTIC_FXA_LOG_ENABLED = values.BooleanValue(False, environ_name="ACOUSTIC_FXA_LOG_ENABLED")
 
-if not UNITTEST:
-    sentry_sdk.init(
-        dsn=config("SENTRY_DSN", None),
-        release=config("GIT_SHA", None),
-        server_name=".".join(x for x in [K8S_NAMESPACE, CLUSTER_NAME, HOSTNAME] if x),
-        integrations=[DjangoIntegration(signals_spans=False), RedisIntegration(), RqIntegration()],
-        before_send=before_send,
+    ACOUSTIC_TX_CLIENT_ID = values.Value(None, environ_name="ACOUSTIC_TX_CLIENT_ID")
+    ACOUSTIC_TX_CLIENT_SECRET = values.Value(None, environ_name="ACOUSTIC_TX_CLIENT_SECRET")
+    ACOUSTIC_TX_REFRESH_TOKEN = values.Value(None, environ_name="ACOUSTIC_TX_REFRESH_TOKEN")
+    ACOUSTIC_TX_SERVER_NUMBER = values.Value(None, environ_name="ACOUSTIC_TX_SERVER_NUMBER")
+    # Send confirmation messages via Acoustic Transact
+    SEND_CONFIRM_MESSAGES = values.BooleanValue(False, environ_name="SEND_CONFIRM_MESSAGES")
+
+    # Mozilla CTMS
+    CTMS_ENV = values.Value("", environ_name="CTMS_ENV").lower()
+    CTMS_ENABLED = values.BooleanValue(False, environ_name="CTMS_ENABLED")
+    if CTMS_ENV == "stage":
+        default_url = "https://ctms.stage.mozilla-ess.mozit.cloud"
+    elif CTMS_ENV == "prod":
+        default_url = "https://ctms.prod.mozilla-ess.mozit.cloud"
+    else:
+        default_url = ""
+    CTMS_URL = values.Value(default_url, environ_name="CTMS_URL")
+    CTMS_CLIENT_ID = values.Value("", environ_name="CTMS_CLIENT_ID")
+    CTMS_CLIENT_SECRET = values.Value("", environ_name="CTMS_CLIENT_SECRET")
+
+    CORS_ORIGIN_ALLOW_ALL = True
+    CORS_URLS_REGEX = r"^/(news/|subscribe)"
+
+    # Security settings
+    USE_X_FORWARDED_HOST = True
+    SESSION_COOKIE_SECURE = True
+    SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+    CSRF_COOKIE_SECURE = True
+
+    RATELIMIT_VIEW = "basket.news.views.ratelimited"
+
+    RQ_RESULT_TTL = values.IntegerValue(0, environ_name="RQ_RESULT_TTL")  # Ignore results.
+    RQ_MAX_RETRY_DELAY = values.IntegerValue(34 * 60 * 60, environ_name="RQ_MAX_RETRY_DELAY")  # 34 hours in seconds.
+    RQ_MAX_RETRIES = values.IntegerValue(12, environ_name="RQ_MAX_RETRIES")
+    RQ_EXCEPTION_HANDLERS = ["basket.base.rq.store_task_exception_handler"]
+    RQ_IS_ASYNC = values.BooleanValue(True, environ_name="RQ_IS_ASYNC")
+
+    SNITCH_ID = values.Value(None, environ_name="SNITCH_ID")
+
+    TESTING_EMAIL_DOMAINS = values.ListValue(
+        ["restmail.net", "restmail.lcip.org", "example.com"],
+        environ_name="TESTING_EMAIL_DOMAINS",
     )
 
-STATSD_HOST = config("STATSD_HOST", get_default_gateway_linux())
-STATSD_PORT = config("STATSD_PORT", 8125, cast=int)
-STATSD_PREFIX = config("STATSD_PREFIX", K8S_NAMESPACE)
+    # language codes we support and send to backend regardless if they exist in the DB
+    EXTRA_SUPPORTED_LANGS = values.ListValue([], environ_name="EXTRA_SUPPORTED_LANGS")
 
-if LOCAL_DEV:
+    PROD_DETAILS_CACHE_NAME = "product_details"
+    PROD_DETAILS_CACHE_TIMEOUT = None
+
+    MAINTENANCE_MODE = values.BooleanValue(False, environ_name="MAINTENANCE_MODE")
+    QUEUE_BATCH_SIZE = values.IntegerValue(500, environ_name="QUEUE_BATCH_SIZE")
+    # can we read user data in maintenance mode
+    MAINTENANCE_READ_ONLY = values.BooleanValue(False, environ_name="MAINTENANCE_READ_ONLY")
+    USE_SANDBOX_BACKEND = values.BooleanValue(False, environ_name="USE_SANDBOX_BACKEND")
+
+    FXA_EVENTS_QUEUE_ENABLE = values.BooleanValue(False, environ_name="FXA_EVENTS_QUEUE_ENABLE")
+    FXA_EVENTS_QUEUE_IGNORE_MODE = values.BooleanValue(False, environ_name="FXA_EVENTS_QUEUE_IGNORE_MODE")
+    FXA_EVENTS_ACCESS_KEY_ID = values.Value("", environ_name="FXA_EVENTS_ACCESS_KEY_ID")
+    FXA_EVENTS_SECRET_ACCESS_KEY = values.Value("", environ_name="FXA_EVENTS_SECRET_ACCESS_KEY")
+    FXA_EVENTS_QUEUE_REGION = values.Value("", environ_name="FXA_EVENTS_QUEUE_REGION")
+    FXA_EVENTS_QUEUE_URL = values.Value("", environ_name="FXA_EVENTS_QUEUE_URL")
+    FXA_EVENTS_QUEUE_WAIT_TIME = values.IntegerValue(10, environ_name="FXA_EVENTS_QUEUE_WAIT_TIME")
+    FXA_EVENTS_SNITCH_ID = values.Value("", environ_name="FXA_EVENTS_SNITCH_ID")
+
+    # stable, stage, or production
+    # https://github.com/mozilla/PyFxA/blob/master/fxa/constants.py
+    FXA_OAUTH_SERVER_ENV = values.Value("stable", environ_name="FXA_OAUTH_SERVER_ENV")
+    FXA_CLIENT_ID = values.Value("", environ_name="FXA_CLIENT_ID")
+    FXA_CLIENT_SECRET = values.Value("", environ_name="FXA_CLIENT_SECRET")
+    FXA_OAUTH_TOKEN_TTL = values.IntegerValue(300, environ_name="FXA_OAUTH_TOKEN_TTL")  # 5 minutes
+
+    FXA_EMAIL_PREFS_DOMAIN = values.Value("www.mozilla.org", environ_name="FXA_EMAIL_PREFS_DOMAIN")
+    FXA_REGISTER_NEWSLETTER = values.Value("firefox-accounts-journey", environ_name="FXA_REGISTER_NEWSLETTER")
+    FXA_REGISTER_SOURCE_URL = values.Value("https://accounts.firefox.com/", environ_name="FXA_REGISTER_SOURCE_URL")
+    # TODO move this to the DB
+    FXA_LOGIN_CAMPAIGNS = {
+        "fxa-embedded-form-moz": "mozilla-welcome",
+        "fxa-embedded-form-fx": "firefox-welcome",
+        "membership-idealo": "member-idealo",
+        "membership-comm": "member-comm",
+        "membership-tech": "member-tech",
+        "membership-tk": "member-tk",
+    }
+    COMMON_VOICE_NEWSLETTER = values.Value("common-voice", environ_name="COMMON_VOICE_NEWSLETTER")
+
+    OIDC_ENABLE = values.BooleanValue(False, environ_name="OIDC_ENABLE")
+    if OIDC_ENABLE:
+        AUTHENTICATION_BACKENDS = ("basket.base.authentication.OIDCModelBackend",)
+        OIDC_OP_AUTHORIZATION_ENDPOINT = values.Value("", environ_name="OIDC_OP_AUTHORIZATION_ENDPOINT")
+        OIDC_OP_TOKEN_ENDPOINT = values.Value("", environ_name="OIDC_OP_TOKEN_ENDPOINT")
+        OIDC_OP_USER_ENDPOINT = values.Value("", environ_name="OIDC_OP_USER_ENDPOINT")
+
+        OIDC_RP_CLIENT_ID = values.Value("", environ_name="OIDC_RP_CLIENT_ID")
+        OIDC_RP_CLIENT_SECRET = values.Value("", environ_name="OIDC_RP_CLIENT_SECRET")
+        OIDC_CREATE_USER = values.BooleanValue(False, environ_name="OIDC_CREATE_USER")
+        LOGIN_REDIRECT_URL = "/admin/"
+        OIDC_EXEMPT_URLS = [
+            "/",
+            "/fxa/",
+            "/fxa/callback/",
+            re.compile(r"^/news/*"),
+            "/subscribe/",
+            "/subscribe.json",
+            # Health checks.
+            "/healthz/",
+            "/readiness/",
+            "/watchman/",
+        ]
+
+    PETITION_CORS_URL = values.Value("https://open.mozilla.org", environ_name="PETITION_CORS_URL")
+    PETITION_LETTER_URL = values.Value("https://open.mozilla.org/letter", environ_name="PETITION_LETTER_URL")
+    PETITION_THANKS_URL = values.Value("https://open.mozilla.org/letter/thanks", environ_name="PETITION_THANKS_URL")
+    PETITION_BUILD_HOOK_URL = values.Value("", environ_name="PETITION_BUILD_HOOK_URL")
+
+
+class Local(Base):
+    DEBUG = values.BooleanValue(True)
+    TEMPLATE_DEBUG = DEBUG
     MARKUS_BACKENDS = [
         {"class": "markus.backends.logging.LoggingMetrics", "options": {"logger_name": "metrics"}},
     ]
-else:
+    markus.configure(backends=MARKUS_BACKENDS)
+
+
+class Testing(Local):
+    DATABASES = values.DatabaseURLValue("mysql://root@db/basket", environ=False)
+    RQ_IS_ASYNC = False
+    RQ_MAX_RETRIES = 0
+    TESTING_EMAIL_DOMAINS = []
+
+
+class Production(Base, SentryConfigurationMixin):
+    DEBUG = False
+    TEMPLATE_DEBUG = DEBUG
+
+    DATABASES = values.DatabaseURLValue().value
+    if DATABASES["default"]["ENGINE"] == "django.db.backends.mysql":
+        DATABASES["default"]["OPTIONS"] = {
+            "init_command": "SET sql_mode='STRICT_TRANS_TABLES'",
+        }
+
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    EMAIL_HOST = values.Value("localhost", environ_name="EMAIL_HOST")
+    EMAIL_PORT = values.IntegerValue(25, environ_name="EMAIL_PORT")
+    EMAIL_HOST_USER = values.Value("", environ_name="EMAIL_HOST_USER")
+    EMAIL_HOST_PASSWORD = values.Value("", environ_name="EMAIL_HOST_PASSWORD")
+    EMAIL_USE_TLS = values.BooleanValue(False, environ_name="EMAIL_USE_TLS")
+    EMAIL_SUBJECT_PREFIX = values.Value("[basket] ", environ_name="EMAIL_SUBJECT_PREFIX")
+
+    ALLOWED_HOSTS = values.ListValue(
+        [".allizom.org", ".moz.works", "basket.mozmar.org", "basket.mozilla.com", "basket.mozilla.org"],
+        environ_name="ALLOWED_HOSTS",
+    )
+    ALLOWED_CIDR_NETS = values.ListValue([], environ_name="ALLOWED_CIDR_NETS")
+    STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+
+    # Security middleware settings
+    SECURE_HSTS_SECONDS = 0
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = False
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    SECURE_SSL_REDIRECT = values.BooleanValue(False, environ_name="SECURE_SSL_REDIRECT")
+    SECURE_REDIRECT_EXEMPT = [
+        r"^healthz/$",
+        r"^readiness/$",
+    ]
+    if SECURE_SSL_REDIRECT:
+        SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+    WATCHMAN_DISABLE_APM = True
+    WATCHMAN_CHECKS = (
+        "watchman.checks.caches",
+        "watchman.checks.databases",
+    )
+
+    STATSD_HOST = values.Value("localhost", environ_name="STATSD_HOST")
+    STATSD_PORT = values.IntegerValue(8125, environ_name="STATSD_PORT")
+    STATSD_PREFIX = values.Value(Base.K8S_NAMESPACE, environ_name="STATSD_PREFIX")
+
     MARKUS_BACKENDS = [
         {
             "class": "markus.backends.datadog.DatadogMetrics",
@@ -340,132 +413,4 @@ else:
             },
         },
     ]
-
-markus.configure(backends=MARKUS_BACKENDS)
-
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "root": {
-        "level": config("DJANGO_LOG_LEVEL", default="WARNING"),
-        "handlers": ["console"],
-    },
-    "formatters": {
-        "verbose": {"format": "%(levelname)s %(asctime)s %(module)s %(message)s"},
-    },
-    "handlers": {
-        "console": {
-            "level": "DEBUG",
-            "class": "logging.StreamHandler",
-            "formatter": "verbose",
-        },
-        "null": {"class": "logging.NullHandler"},
-    },
-    "loggers": {
-        "django.db.backends": {
-            "level": "ERROR",
-            "handlers": ["console"],
-            "propagate": False,
-        },
-        "suds.client": {"level": "ERROR", "handlers": ["console"], "propagate": False},
-    },
-}
-
-# DisallowedHost gets a lot of action thanks to scans/bots/scripts,
-# but we need not take any action because it's already HTTP 400-ed.
-# Note that we ignore at the Sentry client level
-
-ignore_logger("django.security.DisallowedHost")
-
-PROD_DETAILS_CACHE_NAME = "product_details"
-PROD_DETAILS_CACHE_TIMEOUT = None
-
-# language codes that we support and send through to backend
-# regardless of their existence in the DB
-EXTRA_SUPPORTED_LANGS = config("EXTRA_SUPPORTED_LANGS", "", cast=Csv())
-
-if UNITTEST:
-    TESTING_EMAIL_DOMAINS = []
-else:
-    TESTING_EMAIL_DOMAINS = config(
-        "TESTING_EMAIL_DOMAINS",
-        "restmail.net,restmail.lcip.org,example.com",
-        cast=Csv(),
-    )
-
-MAINTENANCE_MODE = config("MAINTENANCE_MODE", False, cast=bool)
-QUEUE_BATCH_SIZE = config("QUEUE_BATCH_SIZE", 500, cast=int)
-# can we read user data in maintenance mode
-MAINTENANCE_READ_ONLY = config("MAINTENANCE_READ_ONLY", False, cast=bool)
-
-USE_SANDBOX_BACKEND = config("USE_SANDBOX_BACKEND", False, cast=bool)
-
-FXA_EVENTS_QUEUE_ENABLE = config("FXA_EVENTS_QUEUE_ENABLE", cast=bool, default=False)
-FXA_EVENTS_QUEUE_IGNORE_MODE = config(
-    "FXA_EVENTS_QUEUE_IGNORE_MODE",
-    cast=bool,
-    default=False,
-)
-FXA_EVENTS_ACCESS_KEY_ID = config("FXA_EVENTS_ACCESS_KEY_ID", default="")
-FXA_EVENTS_SECRET_ACCESS_KEY = config("FXA_EVENTS_SECRET_ACCESS_KEY", default="")
-FXA_EVENTS_QUEUE_REGION = config("FXA_EVENTS_QUEUE_REGION", default="")
-FXA_EVENTS_QUEUE_URL = config("FXA_EVENTS_QUEUE_URL", default="")
-FXA_EVENTS_QUEUE_WAIT_TIME = config("FXA_EVENTS_QUEUE_WAIT_TIME", cast=int, default=10)
-FXA_EVENTS_SNITCH_ID = config("FXA_EVENTS_SNITCH_ID", default="")
-
-# stable, stage, or production
-# https://github.com/mozilla/PyFxA/blob/master/fxa/constants.py
-FXA_OAUTH_SERVER_ENV = config("FXA_OAUTH_SERVER_ENV", default="stable")
-FXA_CLIENT_ID = config("FXA_CLIENT_ID", default="")
-FXA_CLIENT_SECRET = config("FXA_CLIENT_SECRET", default="")
-FXA_OAUTH_TOKEN_TTL = config("FXA_OAUTH_TOKEN_TTL", default=300, cast=int)  # 5 minutes
-
-FXA_EMAIL_PREFS_DOMAIN = config("FXA_EMAIL_PREFS_DOMAIN", default="www.mozilla.org")
-FXA_REGISTER_NEWSLETTER = config(
-    "FXA_REGISTER_NEWSLETTER",
-    default="firefox-accounts-journey",
-)
-FXA_REGISTER_SOURCE_URL = config(
-    "FXA_REGISTER_SOURCE_URL",
-    default="https://accounts.firefox.com/",
-)
-# TODO move this to the DB
-FXA_LOGIN_CAMPAIGNS = {
-    "fxa-embedded-form-moz": "mozilla-welcome",
-    "fxa-embedded-form-fx": "firefox-welcome",
-    "membership-idealo": "member-idealo",
-    "membership-comm": "member-comm",
-    "membership-tech": "member-tech",
-    "membership-tk": "member-tk",
-}
-
-COMMON_VOICE_NEWSLETTER = config("COMMON_VOICE_NEWSLETTER", default="common-voice")
-
-OIDC_ENABLE = config("OIDC_ENABLE", default=False, cast=bool)
-if OIDC_ENABLE:
-    AUTHENTICATION_BACKENDS = ("basket.base.authentication.OIDCModelBackend",)
-    OIDC_OP_AUTHORIZATION_ENDPOINT = config("OIDC_OP_AUTHORIZATION_ENDPOINT")
-    OIDC_OP_TOKEN_ENDPOINT = config("OIDC_OP_TOKEN_ENDPOINT")
-    OIDC_OP_USER_ENDPOINT = config("OIDC_OP_USER_ENDPOINT")
-
-    OIDC_RP_CLIENT_ID = config("OIDC_RP_CLIENT_ID")
-    OIDC_RP_CLIENT_SECRET = config("OIDC_RP_CLIENT_SECRET")
-    OIDC_CREATE_USER = config("OIDC_CREATE_USER", default=False, cast=bool)
-    LOGIN_REDIRECT_URL = "/admin/"
-    OIDC_EXEMPT_URLS = [
-        "/",
-        "/fxa/",
-        "/fxa/callback/",
-        re.compile(r"^/news/*"),
-        "/subscribe/",
-        "/subscribe.json",
-        # Health checks.
-        "/healthz/",
-        "/readiness/",
-        "/watchman/",
-    ]
-
-PETITION_CORS_URL = config("PETITION_CORS_URL", default="https://open.mozilla.org")
-PETITION_LETTER_URL = config("PETITION_LETTER_URL", default="https://open.mozilla.org/letter")
-PETITION_THANKS_URL = config("PETITION_THANKS_URL", default="https://open.mozilla.org/letter/thanks")
-PETITION_BUILD_HOOK_URL = config("PETITION_BUILD_HOOK_URL", default=None)
+    markus.configure(backends=MARKUS_BACKENDS)

--- a/basket/urls.py
+++ b/basket/urls.py
@@ -33,13 +33,3 @@ urlpatterns.extend(
         path("admin/", admin.site.urls),
     ],
 )
-
-if settings.UNITTEST:
-    # Added to help test the 500 statsd metrics in unit tests.
-    from django.views import defaults
-
-    urlpatterns.extend(
-        [
-            path("500/", defaults.server_error),
-        ]
-    )

--- a/basket/wsgi.py
+++ b/basket/wsgi.py
@@ -2,9 +2,10 @@
 import os
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "basket.settings")
+os.environ.setdefault("DJANGO_CONFIGURATION", "Local")
 
 from django.core.handlers.wsgi import WSGIRequest
-from django.core.wsgi import get_wsgi_application
+from configurations.wsgi import get_wsgi_application
 
 IS_HTTPS = os.environ.get("HTTPS", "").strip() == "on"
 

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -7,7 +7,7 @@ ruff format --check basket/
 urlwait
 python manage.py makemigrations | grep "No changes detected"
 python manage.py migrate --noinput
-py.test basket \
+py.test --dc=Testing basket \
   --cov-config=.coveragerc \
   --cov-report=html \
   --cov-report=term-missing \

--- a/docker/envfiles/local.env
+++ b/docker/envfiles/local.env
@@ -1,8 +1,8 @@
 ALLOWED_HOSTS=localhost,127.0.0.1,testserver
 DATABASE_URL=mysql://root@db/basket
 DEBUG=True
+DJANGO_CONFIGURATION=Local
 DJANGO_LOG_LEVEL=DEBUG
-LOCAL_DEV=True
 REDIS_URL=redis://redis:6379
 URLWAIT_TIMEOUT=30
 # Setting max_jobs low to test worker completion and restarts via Docker compose.

--- a/docker/envfiles/test.env
+++ b/docker/envfiles/test.env
@@ -1,10 +1,8 @@
 ADMINS=["thedude@example.com"]
 ALLOWED_HOSTS=*
 DATABASE_URL=mysql://root@db/basket
-
 DEBUG=False
 DEV=False
+DJANGO_CONFIGURATION=Testing
 DJANGO_SETTINGS_MODULE=basket.settings
-LOCAL_DEV=True
 SECRET_KEY=ssssssssshhhhhhhhhh
-UNITTEST=True

--- a/env-dist
+++ b/env-dist
@@ -1,5 +1,5 @@
+DJANGO_CONFIGURATION=Local
 DEBUG=True
-LOCAL_DEV=True
 
 # change this to something secret when deployed
 SECRET_KEY=sssssssshhhhhhhhhh

--- a/manage.py
+++ b/manage.py
@@ -4,7 +4,8 @@ import sys
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "basket.settings")
+    os.environ.setdefault("DJANGO_CONFIGURATION", "Local")
 
-    from django.core.management import execute_from_command_line
+    from configurations.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,4 +30,5 @@ django = ["django"]
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "basket.settings"
+DJANGO_CONFIGURATION = "Testing"
 addopts = "-ra --ignore=vendor"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -342,6 +342,7 @@ django==3.2.23 \
     #   -r requirements/prod.txt
     #   dj-database-url
     #   django-allow-cidr
+    #   django-configurations
     #   django-cors-headers
     #   django-extensions
     #   django-mozilla-product-details
@@ -356,6 +357,10 @@ django-allow-cidr==0.7.1 \
 django-cache-url==3.4.4 \
     --hash=sha256:5ca4760b4580b80e41279bc60d1e5c16a822e4e462265faab0a330701bb0ef9a \
     --hash=sha256:ef2cfacea361ee22e9b67d6ca941db22e0a9eaf892b67ca71cad52c62a17fd36
+    # via -r requirements/prod.txt
+django-configurations==2.5 \
+    --hash=sha256:63fa252c40dc88ea17b8b90f5f4a31a2726e586acb1ff0edc74c228c61f19e5d \
+    --hash=sha256:cf063b99ad30013df49eaa971bd8543deffb008ff080cf3a92955dbccfe81a5c
     # via -r requirements/prod.txt
 django-cors-headers==4.3.1 \
     --hash=sha256:0b1fd19297e37417fc9f835d39e45c8c642938ddba1acce0c1753d3edef04f36 \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -7,6 +7,7 @@ cryptography==41.0.7
 dj-database-url==2.1.0
 django-allow-cidr==0.7.1
 django-cache-url==3.4.4
+django-configurations==2.5
 django-cors-headers==4.3.1
 django-extensions==3.2.3
 django-mozilla-product-details==1.0.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -268,6 +268,7 @@ django==3.2.23 \
     #   -r requirements/prod.in
     #   dj-database-url
     #   django-allow-cidr
+    #   django-configurations
     #   django-cors-headers
     #   django-extensions
     #   django-mozilla-product-details
@@ -282,6 +283,10 @@ django-allow-cidr==0.7.1 \
 django-cache-url==3.4.4 \
     --hash=sha256:5ca4760b4580b80e41279bc60d1e5c16a822e4e462265faab0a330701bb0ef9a \
     --hash=sha256:ef2cfacea361ee22e9b67d6ca941db22e0a9eaf892b67ca71cad52c62a17fd36
+    # via -r requirements/prod.in
+django-configurations==2.5 \
+    --hash=sha256:63fa252c40dc88ea17b8b90f5f4a31a2726e586acb1ff0edc74c228c61f19e5d \
+    --hash=sha256:cf063b99ad30013df49eaa971bd8543deffb008ff080cf3a92955dbccfe81a5c
     # via -r requirements/prod.in
 django-cors-headers==4.3.1 \
     --hash=sha256:0b1fd19297e37417fc9f835d39e45c8c642938ddba1acce0c1753d3edef04f36 \


### PR DESCRIPTION
I wanted to see what moving to django-configurations would look like. Overall I think it is an improvement. It's probably easier to view the settings file complete rather than the diff here.

Things I like:
- Simplifies overriding env vars in certain environments, e.g. `Testing`, or enabling sentry only in `Production` environments.
- Could easily allow for custom settings per deploy environment by adding `Dev`/`Stage`/`Prod` subclasses of `Production`. But, since we try to follow 12-factor, for now just using the env vars is all we needed here.
- Basket wasn't using the pattern of breaking settings across files and using `from base import *`, but django-configurations helps clean up that pattern using Python inheritance.

I'm interested in your thoughts with the consideration of using this across the MEAO org.