### PR TITLE
Add Braze message ID map

### DIFF
--- a/basket/news/models.py
+++ b/basket/news/models.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+from django.conf import settings
 from django.db import models
 from django.utils.timezone import now
 
@@ -295,6 +296,9 @@ class BrazeTxEmailMessageManager(models.Manager):
                         sentry_sdk.capture_exception()
 
         return message
+
+    def get_tx_message_ids(self):
+        return list(set(list(self.filter(private=False).values_list("message_id", flat=True)) + list(settings.BRAZE_MESSAGE_ID_MAP.keys())))
 
 
 class BrazeTxEmailMessage(models.Model):

--- a/basket/news/newsletters.py
+++ b/basket/news/newsletters.py
@@ -28,13 +28,6 @@ def get_transactional_message_ids():
     return list(AcousticTxEmailMessage.objects.filter(private=False).values_list("message_id", flat=True))
 
 
-def get_tx_message_ids():
-    """
-    Returns a list of Braze transactional message IDs that basket clients send.
-    """
-    return list(BrazeTxEmailMessage.objects.filter(private=False).values_list("message_id", flat=True))
-
-
 def _newsletters():
     """Returns a data structure with the data about newsletters.
     It's cached until clear_newsletter_cache() is called, so we're

--- a/basket/news/tests/test_models.py
+++ b/basket/news/tests/test_models.py
@@ -84,6 +84,14 @@ class BrazeTxEmailTests(TestCase):
             "en",
         )
 
+    @override_settings(BRAZE_MESSAGE_ID_MAP={})
+    def test_get_tx_message_ids(self):
+        assert ["the-dude"] == models.BrazeTxEmailMessage.objects.get_tx_message_ids()
+
+    @override_settings(BRAZE_MESSAGE_ID_MAP={"jeff-dowd": "the-dude"})
+    def test_get_tx_message_ids_with_map(self):
+        assert ["the-dude", "jeff-dowd"] == models.BrazeTxEmailMessage.objects.get_tx_message_ids()
+
 
 class FailedTaskTest(TestCase):
     args = [{"case_type": "ringer", "email": "dude@example.com"}, "walter"]

--- a/basket/news/tests/test_update_user_task.py
+++ b/basket/news/tests/test_update_user_task.py
@@ -152,7 +152,7 @@ class UpdateUserTaskTests(TestCase, TasksPatcherMixin):
         request = self.factory.post("/")
         data = {"email": "a@example.com", "newsletters": "tx-foo"}
 
-        with patch("basket.news.views.get_tx_message_ids") as get_tx_message_ids:
+        with patch("basket.news.models.BrazeTxEmailMessage.objects.get_tx_message_ids") as get_tx_message_ids:
             get_tx_message_ids.return_value = ["tx-foo"]
             response = views.update_user_task(request, SUBSCRIBE, data, sync=False)
             self.assert_response_ok(response)

--- a/basket/news/tests/test_upsert_user.py
+++ b/basket/news/tests/test_upsert_user.py
@@ -691,7 +691,7 @@ class UpsertUserTests(TestCase):
             "newsletters": "download-foo",
             "email": self.email,
         }
-        with patch("basket.news.tasks.get_tx_message_ids") as get_tx_message_ids:
+        with patch("basket.news.models.BrazeTxEmailMessage.objects.get_tx_message_ids") as get_tx_message_ids:
             get_tx_message_ids.return_value = ["download-foo"]
             upsert_user(SUBSCRIBE, data)
             braze_mock.assert_called_with("dude@example.com", "en", ["download-foo"])

--- a/basket/news/views.py
+++ b/basket/news/views.py
@@ -23,10 +23,9 @@ from basket.news.forms import (
     SubscribeForm,
     UpdateUserMeta,
 )
-from basket.news.models import Newsletter
+from basket.news.models import BrazeTxEmailMessage, Newsletter
 from basket.news.newsletters import (
     get_transactional_message_ids,
-    get_tx_message_ids,
     newsletter_and_group_slugs,
     newsletter_languages,
     newsletter_private_slugs,
@@ -727,7 +726,7 @@ def update_user_task(request, api_call_type, data=None, optin=False, sync=False)
     newsletters = parse_newsletters_csv(data.get("newsletters"))
     if newsletters:
         if api_call_type == SUBSCRIBE:
-            braze_msg_ids = set(get_tx_message_ids())
+            braze_msg_ids = set(BrazeTxEmailMessage.objects.get_tx_message_ids())
             acoustic_msg_ids = set(get_transactional_message_ids())
             all_transactionals = list(braze_msg_ids | acoustic_msg_ids)
             all_newsletters = newsletter_and_group_slugs() + all_transactionals

--- a/basket/settings.py
+++ b/basket/settings.py
@@ -226,6 +226,12 @@ SEND_CONFIRM_MESSAGES = config("SEND_CONFIRM_MESSAGES", False, cast=bool)
 
 BRAZE_API_KEY = config("BRAZE_API_KEY", None)
 BRAZE_BASE_API_URL = config("BRAZE_BASE_API_URL", "https://rest.iad-05.braze.com")
+# Map of Braze message IDs to the actual message IDs.
+# This is intended for older messages that are hard to change.
+BRAZE_MESSAGE_ID_MAP = {
+    "download-firefox-mobile-whatsnew": "download-firefox-mobile",
+    "firefox-mobile-welcome": "download-firefox-mobile",
+}
 
 # Mozilla CTMS
 CTMS_ENV = config("CTMS_ENV", "").lower()


### PR DESCRIPTION
Some of the old Acoustic message IDs are on website we have no control over, so to change these we need a map.