### PR TITLE
Amend all usage of docker-compose to be docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DC_CI = bin/dc.sh
-DC = docker-compose
+DC = docker compose
 
 all: help
 
@@ -89,7 +89,7 @@ install-local-python-deps:
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  run                  - docker-compose up the entire system for dev"
+	@echo "  run                  - 'docker compose' up the entire system for dev"
 	@echo "  build                - build docker images for dev"
 	@echo "  pull                 - pull the latest production images from Docker Hub"
 	@echo "  run-shell            - open a bash shell in a fresh container"

--- a/bin/dc.sh
+++ b/bin/dc.sh
@@ -2,7 +2,7 @@
 
 source docker/bin/set_git_env_vars.sh
 
-# create empty file for docker-compose
+# create empty file for docker compose
 touch .env
 
-docker-compose "$@"
+docker compose "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   db:
     image: mariadb

--- a/docker/bin/push2dockerhub.sh
+++ b/docker/bin/push2dockerhub.sh
@@ -5,7 +5,7 @@ BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $BIN_DIR/set_git_env_vars.sh
 
 # Push to docker hub
-docker-compose push web
+docker compose push web
 
 if [[ "$GIT_BRANCH" == "prod" ]]; then
     # git tag


### PR DESCRIPTION
This is because the ubuntu-latest GHA image no longer supports the V1 compose API, which was breaking our CI.

https://github.com/actions/runner-images/issues/9692