### PR TITLE
Fix #1466: Don't create a new user when primary email changes

### DIFF
--- a/basket/news/tests/test_views.py
+++ b/basket/news/tests/test_views.py
@@ -888,7 +888,7 @@ class FxAPrefCenterOauthCallbackTests(ViewsPatcherMixin, TasksPatcherMixin, Test
         """Should return a redirect to email pref center"""
         fxa_oauth_mock, fxa_profile_mock = Mock(), Mock()
         fxa_oauth_mock.trade_code.return_value = {"access_token": "access-token"}
-        fxa_profile_mock.get_profile.return_value = {"email": "dude@example.com"}
+        fxa_profile_mock.get_profile.return_value = {"email": "dude@example.com", "uid": "abc123"}
         self.get_fxa_clients.return_value = fxa_oauth_mock, fxa_profile_mock
         self.get_user_data.return_value = {"token": "the-token"}
         session = self.client.session
@@ -907,7 +907,7 @@ class FxAPrefCenterOauthCallbackTests(ViewsPatcherMixin, TasksPatcherMixin, Test
         fxa_profile_mock.get_profile.assert_called_with("access-token")
         metricsmock.assert_incr_once("news.views.fxa_callback", tags=["status:success"])
         assert resp["location"] == "https://www.mozilla.org/newsletter/existing/the-token/?fxa=1"
-        self.get_user_data.assert_called_with(email="dude@example.com")
+        self.get_user_data.assert_called_with(email="dude@example.com", fxa_id="abc123")
 
     @mock_metrics
     def test_new_user_with_locale(self, metricsmock):
@@ -937,7 +937,7 @@ class FxAPrefCenterOauthCallbackTests(ViewsPatcherMixin, TasksPatcherMixin, Test
         fxa_profile_mock.get_profile.assert_called_with("access-token")
         metricsmock.assert_incr_once("news.views.fxa_callback", tags=["status:success"])
         assert resp["location"] == "https://www.mozilla.org/newsletter/existing/the-new-token/?fxa=1"
-        self.get_user_data.assert_called_with(email="dude@example.com")
+        self.get_user_data.assert_called_with(email="dude@example.com", fxa_id=None)
         self.upsert_contact.assert_called_with(
             SUBSCRIBE,
             {
@@ -978,7 +978,7 @@ class FxAPrefCenterOauthCallbackTests(ViewsPatcherMixin, TasksPatcherMixin, Test
         fxa_profile_mock.get_profile.assert_called_with("access-token")
         metricsmock.assert_incr_once("news.views.fxa_callback", tags=["status:success"])
         assert resp["location"] == "https://www.mozilla.org/newsletter/existing/the-new-token/?fxa=1"
-        self.get_user_data.assert_called_with(email="dude@example.com")
+        self.get_user_data.assert_called_with(email="dude@example.com", fxa_id=None)
         self.upsert_contact.assert_called_with(
             SUBSCRIBE,
             {

--- a/basket/news/views.py
+++ b/basket/news/views.py
@@ -164,9 +164,10 @@ def fxa_callback(request):
         sentry_sdk.capture_exception()
         return HttpResponseRedirect(error_url)
 
-    email = user_profile["email"]
+    email = user_profile.get("email")
+    uid = user_profile.get("uid")
     try:
-        user_data = get_user_data(email=email)
+        user_data = get_user_data(email=email, fxa_id=uid)
     except Exception:
         metrics.incr("news.views.fxa_callback", tags=["status:error", "error:user_data"])
         sentry_sdk.capture_exception()


### PR DESCRIPTION
When a user changes their primary email, without the `fxa_id` in the lookup, basket would query CTMS and get no response and treated this as a new user creating a new user in CTMS with the new email. By including the `fxa_id`, we are able to find the user and process the oauth flow correctly, sending the user on to the prefs center.