### PR TITLE
Upgrade to django-ratelimit==4.1.0

### DIFF
--- a/basket/news/tests/test_update_user_task.py
+++ b/basket/news/tests/test_update_user_task.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from django.core.cache import cache
 from django.test import RequestFactory, TestCase
 
-from ratelimit.exceptions import Ratelimited
+from django_ratelimit.exceptions import Ratelimited
 
 from basket import errors
 from basket.news import views

--- a/basket/settings.py
+++ b/basket/settings.py
@@ -162,7 +162,7 @@ MIDDLEWARE = (
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "basket.base.middleware.MetricsViewTimingMiddleware",
-    "ratelimit.middleware.RatelimitMiddleware",
+    "django_ratelimit.middleware.RatelimitMiddleware",
 )
 
 ROOT_URLCONF = "basket.urls"

--- a/newrelic.ini
+++ b/newrelic.ini
@@ -169,7 +169,7 @@ error_collector.enabled = true
 # To stop specific errors from reporting to the UI, set this to
 # a space separated list of the Python exception type names to
 # ignore. The exception name should be of the form 'module:class'.
-error_collector.ignore_errors = ratelimit.exceptions:Ratelimited
+error_collector.ignore_errors = django_ratelimit.exceptions:Ratelimited
 
 # Browser monitoring is the Real User Monitoring feature of the UI.
 # For those Python web frameworks that are supported, this

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -359,9 +359,9 @@ django-mozilla-product-details==1.0.3 \
     --hash=sha256:1d139ba01f4484f3bb43b72864ce33f249835405449e0dc940217cfa42ce5b46 \
     --hash=sha256:a4aba6a68b296dffe8c1afb95d236cdbd402bd855cd49eef4d8a1a610105fd36
     # via -r requirements/prod.txt
-django-ratelimit==3.0.1 \
-    --hash=sha256:73223d860abd5c5d7b9a807fabb39a6220068129b514be8d78044b52607ab154 \
-    --hash=sha256:857e797f23de948b204a31dba9d88aea3ce731b7a5d926d0240c772e19b5486f
+django-ratelimit==4.1.0 \
+    --hash=sha256:555943b283045b917ad59f196829530d63be2a39adb72788d985b90c81ba808b \
+    --hash=sha256:d047a31cf94d83ef1465d7543ca66c6fc16695559b5f8d814d1b51df15110b92
     # via -r requirements/prod.txt
 django-watchman==1.3.0 \
     --hash=sha256:33b5fc734d689b83cb96fc17beda624ae2955f4cede0856897d990c363eac962 \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -7,7 +7,7 @@ django-allow-cidr==0.7.1
 django-cache-url==3.4.5
 django-cors-headers==4.6.0
 django-mozilla-product-details==1.0.3
-django-ratelimit==3.0.1  # 4.x has breaking changes.
+django-ratelimit==4.1.0
 django-watchman==1.3.0
 django==4.2.16
 email-validator==2.2.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -282,9 +282,9 @@ django-mozilla-product-details==1.0.3 \
     --hash=sha256:1d139ba01f4484f3bb43b72864ce33f249835405449e0dc940217cfa42ce5b46 \
     --hash=sha256:a4aba6a68b296dffe8c1afb95d236cdbd402bd855cd49eef4d8a1a610105fd36
     # via -r requirements/prod.in
-django-ratelimit==3.0.1 \
-    --hash=sha256:73223d860abd5c5d7b9a807fabb39a6220068129b514be8d78044b52607ab154 \
-    --hash=sha256:857e797f23de948b204a31dba9d88aea3ce731b7a5d926d0240c772e19b5486f
+django-ratelimit==4.1.0 \
+    --hash=sha256:555943b283045b917ad59f196829530d63be2a39adb72788d985b90c81ba808b \
+    --hash=sha256:d047a31cf94d83ef1465d7543ca66c6fc16695559b5f8d814d1b51df15110b92
     # via -r requirements/prod.in
 django-watchman==1.3.0 \
     --hash=sha256:33b5fc734d689b83cb96fc17beda624ae2955f4cede0856897d990c363eac962 \


### PR DESCRIPTION
This was a backwards incompatible upgrade from 3.x that required some extra steps.