### PR TITLE
Bring order to the newsletter API

### DIFF
--- a/basket/news/schemas.py
+++ b/basket/news/schemas.py
@@ -11,7 +11,7 @@ class NewsletterSchema(ModelSchema):
 
     class Meta:
         model = Newsletter
-        exclude = ["id", "order"]
+        exclude = ["id"]
 
 
 class NewslettersSchema(Schema):

--- a/basket/news/tests/api/test_newsletters.py
+++ b/basket/news/tests/api/test_newsletters.py
@@ -14,14 +14,15 @@ class TestNewslettersAPI:
     def setup_method(self, method):
         cache.clear()
         self.url = reverse("api.v1:news.newsletters")
-        self.n1 = self._add_newsletter("test-1")
-        self.n2 = self._add_newsletter("test-2")
+        self.n1 = self._add_newsletter("test-1", show=True, order=1)
+        self.n2 = self._add_newsletter("test-2", order=2)
 
-    def _add_newsletter(self, slug):
+    def _add_newsletter(self, slug, **kwargs):
         return models.Newsletter.objects.create(
             slug=slug,
             title=slug,
             languages="en",
+            **kwargs,
         )
 
     def test_newsletters(self, client):
@@ -36,7 +37,7 @@ class TestNewslettersAPI:
         assert n1_data["title"] == "test-1"
         assert n1_data["languages"] == ["en"]
         # defaults
-        assert n1_data["show"] is False
+        assert n1_data["show"] is True
         assert n1_data["active"] is True
         assert n1_data["private"] is False
         assert n1_data["indent"] is False
@@ -44,6 +45,7 @@ class TestNewslettersAPI:
         assert n1_data["firefox_confirm"] is False
         assert n1_data["is_mofo"] is False
         assert n1_data["is_waitlist"] is False
+        assert n1_data["order"] == 1
 
     def test_newsletters_caches_when_called(self, client):
         with patch("django.core.cache.cache.set") as mock_cache_set:


### PR DESCRIPTION
I noticed the ordering of the newsletter list wasn't ordered and traced it to the API missing this field on the ninja conversion.