### PR TITLE
Update docker-compose to use healthchecks

### DIFF
--- a/bin/run-dev.sh
+++ b/bin/run-dev.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -ex
 
-urlwait
 python manage.py migrate --noinput
 
 granian \

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -4,7 +4,6 @@ set -exo pipefail
 
 ruff check basket/
 ruff format --check basket/
-urlwait
 python manage.py makemigrations | grep "No changes detected"
 python manage.py migrate --noinput
 py.test basket \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,22 @@ services:
   db:
     image: mariadb
     environment:
-      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
-      - MYSQL_DATABASE=basket
+      - MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1
+      - MARIADB_DATABASE=basket
+    healthcheck:
+      test: ["CMD", "mariadb", "--user=root", "--execute=SELECT version();"]
+      interval: 5s
+      timeout: 2s
+      retries: 5
 
   redis:
     image: redis
     platform: linux/amd64
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 1s
+      retries: 5
 
   web:
     build:
@@ -16,6 +26,7 @@ services:
         GIT_SHA: ${GIT_COMMIT:-latest}
     image: mozmeao/basket:${GIT_COMMIT_SHORT:-latest}
     platform: linux/amd64
+    init: true
     volumes:
       - .:/app
     env_file:
@@ -24,14 +35,22 @@ services:
     ports:
       - "8000:8000"
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/web/8000"]
+      interval: 3s
+      timeout: 1s
+      retries: 10
     command:
       ./bin/run-dev.sh
 
   worker:
     image: mozmeao/basket:${GIT_COMMIT_SHORT:-latest}
     platform: linux/amd64
+    init: true
     restart: unless-stopped
     volumes:
       - .:/app
@@ -39,8 +58,15 @@ services:
       - docker/envfiles/local.env
       - .env
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "bash", "-c", "rq info -R default | grep -q '1 queues'"]
+      interval: 3s
+      timeout: 1s
+      retries: 5
     command:
       ./bin/run-worker.sh
 
@@ -53,8 +79,10 @@ services:
       - docker/envfiles/local.env
       - docker/envfiles/test.env
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     command:
       ./bin/run-tests.sh
 
@@ -65,8 +93,10 @@ services:
       - docker/envfiles/local.env
       - docker/envfiles/test.env
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     command:
       ./bin/run-tests.sh
 

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -7,6 +7,5 @@ pytest-mock==3.14.0
 pytest==8.3.4
 requests-mock==1.12.1
 ruff==0.8.3
-urlwait==1.0
 uv==0.5.10
 watchfiles==1.0.3  # required for `granian --reload`

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1131,10 +1131,6 @@ urllib3==2.2.3 \
     #   botocore
     #   requests
     #   sentry-sdk
-urlwait==1.0 \
-    --hash=sha256:a9bf2da792fa6983fa93f6360108e16615066ab0f9cfb7f53e5faee5f5dffaac \
-    --hash=sha256:eae2c20001efc915166cac79c04bac0088ad5787ec64b36f27afd2f359953b2b
-    # via -r requirements/dev.in
 user-agents==2.2.0 \
     --hash=sha256:a98c4dc72ecbc64812c4534108806fb0a0b3a11ec3fd1eafe807cee5b0a942e7 \
     --hash=sha256:d36d25178db65308d1458c5fa4ab39c9b2619377010130329f3955e7626ead26


### PR DESCRIPTION
This PR removes the use of the `urlwait` utility for managing service dependencies and replaces it with Docker Compose's native `healthcheck` and `depends_on` functionality. We use `depends_on` with `condition: service_healthy` to ensure dependent services only start when their dependencies are fully operational.

Also, outdated MySQL environment variables were updated to match the current usage of the MariaDB Docker container.

This also gives the `web` and `worker` services an `init: true` which results in faster shutdowns. Docker docs say:
> init runs an init process (PID 1) inside the container that forwards signals and reaps processes. Set this option to true to enable this feature for the service.