### PR TITLE
Use "testqueue" for unit tests

### DIFF
--- a/basket/base/rq.py
+++ b/basket/base/rq.py
@@ -55,11 +55,19 @@ def get_redis_connection(url=None, force=False):
     return _REDIS_CONN
 
 
-def get_queue(queue="default"):
+def get_queue(queue=None):
     """
     Get an RQ queue with our chosen parameters.
 
     """
+    if queue is None:
+        if settings.RQ_DEFAULT_QUEUE:
+            queue = settings.RQ_DEFAULT_QUEUE
+        else:
+            queue = "default"
+    else:
+        queue = queue
+
     return Queue(
         queue,
         connection=get_redis_connection(),
@@ -74,7 +82,7 @@ def get_worker(queues=None):
 
     """
     if queues is None:
-        queues = ["default"]
+        queues = [get_queue()]
 
     return SimpleWorker(
         queues,

--- a/basket/base/tests/test_rq_utils.py
+++ b/basket/base/tests/test_rq_utils.py
@@ -71,9 +71,12 @@ class TestRQUtils:
         # Set back to the "default" for tests that follow since the connection is cached in the module.
         get_redis_connection("redis://redis:6379/2", force=True)
 
+    @override_settings(RQ_DEFAULT_QUEUE="")
     def test_get_queue(self):
         """
-        Test that the get_queue function returns a RQ queue with params we expect.
+        Test that the get_queue function returns a RQ queue with default.
+
+        Note: We set RQ_DEFAULT_QUEUE to an empty string since in tests this is set to "testqueue".
         """
         queue = get_queue()
 
@@ -81,6 +84,29 @@ class TestRQUtils:
         assert queue._is_async is False  # Only during testing.
         assert queue.connection == get_redis_connection()
         assert queue.serializer == JSONSerializer
+
+    @override_settings(RQ_DEFAULT_QUEUE="settings")
+    def test_get_queue_settings(self):
+        """
+        Test that the get_queue function returns a RQ queue if we set the RQ_DEFAULT_QUEUE setting.
+        """
+        queue = get_queue()
+        assert queue.name == "settings"
+
+    @override_settings(RQ_DEFAULT_QUEUE="settings")
+    def test_get_queue_arg_overrides_setting(self):
+        """
+        Test that the get_queue function returns a RQ queue if we pass in a queue name.
+        """
+        queue = get_queue("args")
+        assert queue.name == "args"
+
+    def test_get_queue_unittest(self):
+        """
+        Test that the get_queue function returns the expected queue when running tests.
+        """
+        queue = get_queue()
+        assert queue.name == "testqueue"
 
     def test_get_worker(self):
         """

--- a/basket/settings.py
+++ b/basket/settings.py
@@ -246,6 +246,7 @@ RQ_MAX_RETRY_DELAY = config("RQ_MAX_RETRY_DELAY", parser=int, default=str(34 * 6
 RQ_MAX_RETRIES = 0 if UNITTEST else config("RQ_MAX_RETRIES", parser=int, default="12")
 RQ_EXCEPTION_HANDLERS = ["basket.base.rq.store_task_exception_handler"]
 RQ_IS_ASYNC = False if UNITTEST else config("RQ_IS_ASYNC", parser=bool, default="true")
+RQ_DEFAULT_QUEUE = "testqueue" if UNITTEST else config("RQ_DEFAULT_QUEUE", default="") or None
 
 SNITCH_ID = config("SNITCH_ID", default="")
 


### PR DESCRIPTION
I noticed that when I run basket locally, it often had tasks being retried from the test runs. The retried tasks were being left scheduled in Redis after a test run, so running basket would retry them.

This updates the default queue in tests to use a separate queue. Apparently the `queue.empty()` only clears the active queue, not the `ScheduledJobRegistry`. It looks to be a bit of a pain to remove scheduled jobs, but not impossible. I can add this at some future time.

Regardless, it's probably a better idea to use a separate queue for testing just like we have a separate db for testing.