### PR TITLE
fix(fxa): write fxa_id alias in fxa_callback

### DIFF
--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -101,6 +101,14 @@ def fxa_email_changed(
     cache.set(cache_key, ts, 7200)  # 2 hr
 
 
+def set_user_fxa_id(user_data, fxa_id, use_braze_backend=False):
+    """Write the fxa_id alias for an existing user who doesn't have one yet."""
+    if use_braze_backend:
+        braze.update(user_data, {"fxa_id": fxa_id})
+    else:
+        ctms.update(user_data, {"fxa_id": fxa_id})
+
+
 def fxa_direct_update_contact(fxa_id, data, use_braze_backend=False):
     """Set some small data for a contact with an FxA ID
 

--- a/basket/news/tests/test_views.py
+++ b/basket/news/tests/test_views.py
@@ -810,6 +810,7 @@ class FxAPrefCenterOauthCallbackTests(ViewsPatcherMixin, TasksPatcherMixin, Test
         self._patch_views("get_fxa_clients")
         self._patch_views("sentry_sdk")
         self._patch_tasks("upsert_contact")
+        self._patch_tasks("set_user_fxa_id")
 
     @mock_metrics
     def test_no_session_state(self, metricsmock):

--- a/basket/news/views.py
+++ b/basket/news/views.py
@@ -17,6 +17,8 @@ from django_ratelimit.exceptions import Ratelimited
 
 from basket import errors, metrics
 from basket.news import tasks
+from basket.news.backends.braze import braze
+from basket.news.backends.ctms import ctms
 from basket.news.forms import (
     CommonVoiceForm,
     UpdateUserMeta,
@@ -163,12 +165,18 @@ def fxa_callback(request):
 
         if user_data:
             token = user_data["token"]
+            if uid and not user_data.get("fxa_id"):
+                if use_braze_backend:
+                    braze.update(user_data, {"fxa_id": uid})
+                else:
+                    ctms.update(user_data, {"fxa_id": uid})
         else:
             new_user_data = {
                 "email": email,
                 "optin": True,
                 "newsletters": [settings.FXA_REGISTER_NEWSLETTER],
                 "source_url": f"{settings.FXA_REGISTER_SOURCE_URL}?utm_source=basket-fxa-oauth",
+                "fxa_id": uid,
             }
             locale = user_profile.get("locale")
             if locale:

--- a/basket/news/views.py
+++ b/basket/news/views.py
@@ -17,8 +17,6 @@ from django_ratelimit.exceptions import Ratelimited
 
 from basket import errors, metrics
 from basket.news import tasks
-from basket.news.backends.braze import braze
-from basket.news.backends.ctms import ctms
 from basket.news.forms import (
     CommonVoiceForm,
     UpdateUserMeta,
@@ -166,10 +164,7 @@ def fxa_callback(request):
         if user_data:
             token = user_data["token"]
             if uid and not user_data.get("fxa_id"):
-                if use_braze_backend:
-                    braze.update(user_data, {"fxa_id": uid})
-                else:
-                    ctms.update(user_data, {"fxa_id": uid})
+                tasks.set_user_fxa_id(user_data, uid, use_braze_backend=use_braze_backend)
         else:
             new_user_data = {
                 "email": email,


### PR DESCRIPTION
- New users: add fxa_id to new_user_data so braze.add() enqueues the
  alias task directly (runs 5 minutes later via RQ worker)

- Existing users: write the alias immediately if the user exists in the
  backend but has no fxa_id alias yet (also enqueued, non-blocking)