### PR TITLE
feat(braze): fire custom event to Braze on newsletter subscribe and unsubscribe

### DIFF
--- a/basket/news/backends/braze.py
+++ b/basket/news/backends/braze.py
@@ -581,15 +581,14 @@ class Braze:
                         }
                     )
                 newsletter = newsletter_obj(slug)
-                if newsletter:
-                    action = "subscribe" if is_subscribed else "unsubscribe"
-                    newsletter_events.append(
-                        {
-                            "external_id": external_id,
-                            "name": f"{newsletter.title} - {action}",
-                            "time": now,
-                        }
-                    )
+                action = "subscribe" if is_subscribed else "unsubscribe"
+                newsletter_events.append(
+                    {
+                        "external_id": external_id,
+                        "name": f"{newsletter.title} - {action}",
+                        "time": now,
+                    }
+                )
 
         optin = optin_to_boolean(updated_user_data.get("optin"))
 

--- a/basket/news/backends/braze.py
+++ b/basket/news/backends/braze.py
@@ -15,7 +15,7 @@ from basket import metrics
 from basket.base.decorators import rq_task
 from basket.base.utils import is_valid_uuid
 from basket.news.backends.ctms import ctms, process_country, process_lang
-from basket.news.newsletters import slug_to_vendor_id, vendor_id_to_slug
+from basket.news.newsletters import newsletter_obj, slug_to_vendor_id, vendor_id_to_slug
 
 log = logging.getLogger(__name__)
 
@@ -569,6 +569,7 @@ class Braze:
             raise ValueError("Missing Braze external_id")
 
         subscription_groups = []
+        newsletter_events = []
         if update_data and isinstance(update_data.get("newsletters"), dict):
             for slug, is_subscribed in update_data["newsletters"].items():
                 vendor_id = slug_to_vendor_id(slug)
@@ -577,6 +578,16 @@ class Braze:
                         {
                             "subscription_group_id": vendor_id,
                             "subscription_state": "subscribed" if is_subscribed else "unsubscribed",
+                        }
+                    )
+                newsletter = newsletter_obj(slug)
+                if newsletter:
+                    action = "subscribe" if is_subscribed else "unsubscribe"
+                    newsletter_events.append(
+                        {
+                            "external_id": external_id,
+                            "name": f"{newsletter.title} - {action}",
+                            "time": now,
                         }
                     )
 
@@ -619,8 +630,9 @@ class Braze:
 
         braze_data = {"attributes": [user_attributes]}
 
-        if events:
-            braze_data["events"] = events
+        all_events = newsletter_events + (events or [])
+        if all_events:
+            braze_data["events"] = all_events
 
         return braze_data
 

--- a/basket/news/tests/test_braze.py
+++ b/basket/news/tests/test_braze.py
@@ -348,8 +348,8 @@ mock_newsletters = {
         "78fe6671-9f94-48bd-aaf3-7e873536c3e6": namedtuple("Newsletter", ["slug"])("bar-news"),
     },
     "by_name": {
-        "foo-news": namedtuple("Newsletter", ["vendor_id"])("234c9b4a-1785-4cd5-b839-5dbc134982eb"),
-        "bar-news": namedtuple("Newsletter", ["vendor_id"])("78fe6671-9f94-48bd-aaf3-7e873536c3e6"),
+        "foo-news": namedtuple("Newsletter", ["vendor_id", "title"])("234c9b4a-1785-4cd5-b839-5dbc134982eb", "Foo News"),
+        "bar-news": namedtuple("Newsletter", ["vendor_id", "title"])("78fe6671-9f94-48bd-aaf3-7e873536c3e6", "Bar News"),
     },
 }
 
@@ -456,7 +456,8 @@ def test_to_vendor_with_updates_and_no_user_data(mock_newsletter_languages, mock
                     }
                 ],
             }
-        ]
+        ],
+        "events": [{"external_id": "123", "name": "Bar News - subscribe", "time": dt.isoformat()}],
     }
     with freeze_time(dt):
         assert braze_instance.to_vendor(None, update_data) == expected
@@ -528,7 +529,11 @@ def test_to_vendor_with_both_user_data_and_updates(mock_newsletter_languages, mo
                     }
                 ],
             }
-        ]
+        ],
+        "events": [
+            {"external_id": "123", "name": "Bar News - subscribe", "time": dt.isoformat()},
+            {"external_id": "123", "name": "Foo News - unsubscribe", "time": dt.isoformat()},
+        ],
     }
     with freeze_time(dt):
         assert braze_instance.to_vendor(mock_basket_user_data, update_data) == expected


### PR DESCRIPTION
### Description

For each newsletter subscription change, emit a timestamped Braze custom event named "{Newsletter Title} - subscribe" or "{Newsletter Title} - unsubscribe". This enables time-based segmentation and campaign triggers in Braze.

### Ticket
https://mozilla-hub.atlassian.net/browse/WT-1085
