### PR TITLE
feat(braze): add endpoint for webhook to assign external_ids when mis…

### DIFF
--- a/basket/base/tests/test_throttling.py
+++ b/basket/base/tests/test_throttling.py
@@ -1,6 +1,8 @@
+from types import SimpleNamespace
+
 import pytest
 
-from basket.base.throttling import MultiPeriodThrottle
+from basket.base.throttling import MultiPeriodThrottle, WebhookIdentifierThrottle
 
 
 def test_rate_parser():
@@ -19,3 +21,26 @@ def test_rate_parser():
 
     with pytest.raises(ValueError):
         th.parse_rate("42")
+
+
+def test_webhook_identifier_throttle_keys_on_body_identifier():
+    th = WebhookIdentifierThrottle("4/5m")
+    key = th.get_cache_key(SimpleNamespace(body=b'{"fxa_id": "abc"}'))
+    assert key and "webhook" in key and "abc" in key
+
+
+def test_webhook_identifier_throttle_precedence():
+    # basket_token takes precedence over fxa_id/email.
+    th = WebhookIdentifierThrottle("4/5m")
+    key = th.get_cache_key(SimpleNamespace(body=b'{"basket_token": "tok", "fxa_id": "abc"}'))
+    assert "tok" in key
+
+
+def test_webhook_identifier_throttle_no_identifier_is_unthrottled():
+    th = WebhookIdentifierThrottle("4/5m")
+    assert th.get_cache_key(SimpleNamespace(body=b"{}")) is None
+
+
+def test_webhook_identifier_throttle_malformed_body_is_unthrottled():
+    th = WebhookIdentifierThrottle("4/5m")
+    assert th.get_cache_key(SimpleNamespace(body=b"not json")) is None

--- a/basket/base/tests/test_throttling.py
+++ b/basket/base/tests/test_throttling.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from basket.base.throttling import MultiPeriodThrottle, WebhookIdentifierThrottle
+from basket.base.throttling import MultiPeriodThrottle, WebhookGlobalThrottle, WebhookIdentifierThrottle
 
 
 def test_rate_parser():
@@ -44,3 +44,17 @@ def test_webhook_identifier_throttle_no_identifier_is_unthrottled():
 def test_webhook_identifier_throttle_malformed_body_is_unthrottled():
     th = WebhookIdentifierThrottle("4/5m")
     assert th.get_cache_key(SimpleNamespace(body=b"not json")) is None
+
+
+@pytest.mark.parametrize("body", [b"42", b'"foo"', b"[]", b"null"])
+def test_webhook_identifier_throttle_non_object_json_is_unthrottled(body):
+    # Valid JSON that isn't an object must not raise (regression: `.get()` on a non-dict).
+    th = WebhookIdentifierThrottle("4/5m")
+    assert th.get_cache_key(SimpleNamespace(body=body)) is None
+
+
+def test_webhook_global_throttle_keys_on_constant():
+    th = WebhookGlobalThrottle("600/m")
+    key_a = th.get_cache_key(SimpleNamespace(body=b'{"fxa_id": "abc"}'))
+    key_b = th.get_cache_key(SimpleNamespace(body=b'{"fxa_id": "different"}'))
+    assert key_a == key_b and "webhook_global" in key_a

--- a/basket/base/throttling.py
+++ b/basket/base/throttling.py
@@ -80,6 +80,10 @@ class WebhookIdentifierThrottle(MultiPeriodThrottle):
         except (ValueError, TypeError):
             return None
 
+        if not isinstance(body, dict):
+            # Non-object JSON (`42`, `"x"`, `[]`) has no identifier and would break `.get()`.
+            return None
+
         ident = next((body.get(k) for k in self.identifier_keys if body.get(k)), None)
         if not ident:
             return None
@@ -87,4 +91,18 @@ class WebhookIdentifierThrottle(MultiPeriodThrottle):
         return self.cache_format % {
             "scope": "webhook",
             "ident": ident,
+        }
+
+
+class WebhookGlobalThrottle(MultiPeriodThrottle):
+    """
+    Endpoint-wide rate limit keyed on a constant, so it can't be escaped by varying or
+    omitting the request body. Backstop for WebhookIdentifierThrottle; size to total
+    expected caller volume, not per-user.
+    """
+
+    def get_cache_key(self, request) -> str | None:
+        return self.cache_format % {
+            "scope": "webhook_global",
+            "ident": "all",
         }

--- a/basket/base/throttling.py
+++ b/basket/base/throttling.py
@@ -1,3 +1,5 @@
+import json
+
 from ninja.throttling import SimpleRateThrottle
 
 
@@ -62,4 +64,27 @@ class TokenThrottle(MultiPeriodThrottle):
         return self.cache_format % {
             "scope": "token",
             "ident": token,
+        }
+
+
+class WebhookIdentifierThrottle(MultiPeriodThrottle):
+    """
+    Limits the rate of inbound webhook calls per user identifier in the JSON body.
+    """
+
+    identifier_keys = ("basket_token", "fxa_id", "email")
+
+    def get_cache_key(self, request) -> str | None:
+        try:
+            body = json.loads(request.body or b"{}")
+        except (ValueError, TypeError):
+            return None
+
+        ident = next((body.get(k) for k in self.identifier_keys if body.get(k)), None)
+        if not ident:
+            return None
+
+        return self.cache_format % {
+            "scope": "webhook",
+            "ident": ident,
         }

--- a/basket/news/api.py
+++ b/basket/news/api.py
@@ -258,7 +258,6 @@ def lookup_user(request, email: str | None = None, token: uuid.UUID | None = Non
     response={
         200: OkSchema,
         400: ErrorSchema,
-        401: ErrorSchema,
     },
 )
 def assign_external_id(request, body: AssignExternalIdSchema):

--- a/basket/news/api.py
+++ b/basket/news/api.py
@@ -11,7 +11,7 @@ from ninja.decorators import decorate_view
 from ninja.errors import Throttled, ValidationError
 
 from basket import errors, metrics
-from basket.base.throttling import TokenThrottle, WebhookIdentifierThrottle
+from basket.base.throttling import TokenThrottle, WebhookGlobalThrottle, WebhookIdentifierThrottle
 from basket.base.utils import is_valid_uuid
 from basket.news import tasks
 from basket.news.auth import AUTHORIZED, FxaBearerToken, HeaderApiKey, QueryApiKey, Unauthorized, WebhookBearerToken
@@ -254,7 +254,10 @@ def lookup_user(request, email: str | None = None, token: uuid.UUID | None = Non
     url_name="users.assign",
     description="Webhook: assign an external_id to a user that only has a backend user alias",
     auth=[WebhookBearerToken()],
-    throttle=[WebhookIdentifierThrottle(settings.ASSIGN_RATE_LIMIT)],
+    throttle=[
+        WebhookIdentifierThrottle(settings.ASSIGN_RATE_LIMIT),
+        WebhookGlobalThrottle(settings.ASSIGN_GLOBAL_RATE_LIMIT),
+    ],
     response={
         200: OkSchema,
         400: ErrorSchema,

--- a/basket/news/api.py
+++ b/basket/news/api.py
@@ -11,12 +11,13 @@ from ninja.decorators import decorate_view
 from ninja.errors import Throttled, ValidationError
 
 from basket import errors, metrics
-from basket.base.throttling import TokenThrottle
+from basket.base.throttling import TokenThrottle, WebhookIdentifierThrottle
 from basket.base.utils import is_valid_uuid
 from basket.news import tasks
-from basket.news.auth import AUTHORIZED, FxaBearerToken, HeaderApiKey, QueryApiKey, Unauthorized
+from basket.news.auth import AUTHORIZED, FxaBearerToken, HeaderApiKey, QueryApiKey, Unauthorized, WebhookBearerToken
 from basket.news.models import Newsletter
 from basket.news.schemas import (
+    AssignExternalIdSchema,
     ErrorSchema,
     NewsletterModelSchema,
     NewslettersSchema,
@@ -246,6 +247,37 @@ def lookup_user(request, email: str | None = None, token: uuid.UUID | None = Non
         return _unknown_email()
 
     return user_data
+
+
+@user_router.post(
+    "/assign/",
+    url_name="users.assign",
+    description="Webhook: assign an external_id to a user that only has a backend user alias",
+    auth=[WebhookBearerToken()],
+    throttle=[WebhookIdentifierThrottle(settings.ASSIGN_RATE_LIMIT)],
+    response={
+        200: OkSchema,
+        400: ErrorSchema,
+        401: ErrorSchema,
+    },
+)
+def assign_external_id(request, body: AssignExternalIdSchema):
+    # Auth is enforced by `WebhookBearerToken` (no `Unauthorized()` fallback in `auth=[...]`),
+    # so django-ninja returns 401 before this handler runs — no in-view auth check needed.
+    if not (body.email or body.basket_token or body.fxa_id):
+        return 400, {
+            "status": "error",
+            "desc": "An identifier (email, basket_token, or fxa_id) is required",
+            "code": errors.BASKET_USAGE_ERROR,
+        }
+
+    # Dispatch to whichever backend can assign an external_id. Only the Braze
+    # backend has one; when it isn't the write backend this is a no-op (the
+    # other backends have nothing to assign).
+    if settings.BRAZE_PARALLEL_WRITE_ENABLE or settings.BRAZE_ONLY_WRITE_ENABLE:
+        tasks.braze_assign_external_id.delay(body.dict())
+
+    return {"status": "ok"}
 
 
 ## Validation errors

--- a/basket/news/auth.py
+++ b/basket/news/auth.py
@@ -8,6 +8,7 @@ import sentry_sdk
 from ninja.security import APIKeyHeader, APIKeyQuery, HttpBearer
 from ninja.security.base import AuthBase
 
+from basket import metrics
 from basket.news.models import APIUser
 from basket.news.utils import get_fxa_clients
 
@@ -35,8 +36,15 @@ class HeaderApiKey(APIUserIsValid, APIKeyHeader):
 class WebhookBearerToken(HttpBearer):
     def authenticate(self, request, token):
         secret = settings.ASSIGN_WEBHOOK_SECRET
-        if secret and constant_time_compare(token, secret):
+        if not secret:
+            # Fail-closed, but emit a metric so a deploy that forgot the secret is visible.
+            metrics.incr("news.auth.webhook_bearer", tags=["result:rejected", "reason:not_configured"])
+            return None
+        if constant_time_compare(token, secret):
+            metrics.incr("news.auth.webhook_bearer", tags=["result:accepted"])
             return AUTHORIZED
+        metrics.incr("news.auth.webhook_bearer", tags=["result:rejected", "reason:mismatch"])
+        return None
 
 
 class FxaBearerToken(HttpBearer):

--- a/basket/news/auth.py
+++ b/basket/news/auth.py
@@ -1,5 +1,8 @@
 from abc import ABC
 
+from django.conf import settings
+from django.utils.crypto import constant_time_compare
+
 import fxa.errors
 import sentry_sdk
 from ninja.security import APIKeyHeader, APIKeyQuery, HttpBearer
@@ -27,6 +30,13 @@ class QueryApiKey(APIUserIsValid, APIKeyQuery):
 
 class HeaderApiKey(APIUserIsValid, APIKeyHeader):
     param_name = "X-Api-Key"
+
+
+class WebhookBearerToken(HttpBearer):
+    def authenticate(self, request, token):
+        secret = settings.ASSIGN_WEBHOOK_SECRET
+        if secret and constant_time_compare(token, secret):
+            return AUTHORIZED
 
 
 class FxaBearerToken(HttpBearer):

--- a/basket/news/backends/braze.py
+++ b/basket/news/backends/braze.py
@@ -362,6 +362,8 @@ class BrazeInterface:
             data["aliases_to_identify"] = aliases_to_identify
         if emails_to_identify:
             data["emails_to_identify"] = emails_to_identify
+        if not data:
+            raise ValueError("identify_user requires aliases_to_identify or emails_to_identify")
         return self._request(BrazeEndpoint.USERS_IDENTIFY, data)
 
 

--- a/basket/news/backends/braze.py
+++ b/basket/news/backends/braze.py
@@ -411,8 +411,14 @@ class Braze:
         # email will not be populated. We check for that here, and if there is no email we
         # behave as if the user wasn't found.
         if user_response["users"] and user_response["users"][0].get("email"):
-            metrics.incr("news.backends.braze.get", tags=["status:found"])
             user_data = user_response["users"][0]
+            if not user_data.get("external_id"):
+                # Alias-only profile (found by email/alias but awaiting /users/assign);
+                # not a Basket user yet, so report it as not found.
+                metrics.incr("news.backends.braze.get", tags=["status:alias_only"])
+                return None
+
+            metrics.incr("news.backends.braze.get", tags=["status:found"])
             user_email = email or user_data.get("email")
             is_opted_out = user_data.get("email_subscribe") == "unsubscribed"
             subscriptions = []
@@ -541,8 +547,13 @@ class Braze:
 
     def from_vendor(self, braze_user_data, subscription_groups):
         """
-        Converts Braze-formatted data to Basket-formatted data
+        Converts Braze-formatted data to Basket-formatted data.
+
+        Returns None for an alias-only profile (no external_id): it isn't a Basket user
+        yet (awaiting /users/assign), and callers expect a real token/email_id.
         """
+        if not braze_user_data.get("external_id"):
+            return None
 
         user_attributes = braze_user_data.get("custom_attributes", {}).get("user_attributes_v1", [{}])[0]
         user_aliases = braze_user_data.get("user_aliases", [])

--- a/basket/news/backends/braze.py
+++ b/basket/news/backends/braze.py
@@ -37,6 +37,15 @@ def add_basket_token_alias_task(external_id, basket_token):
     braze.interface.add_basket_token_alias(external_id, basket_token)
 
 
+@rq_task
+def assign_basket_token_alias_task(external_id):
+    # Adds a basket_token alias whose value == external_id, for users given an external_id by
+    # the /users/assign webhook. Uses braze_tx (BRAZE_API_KEY) for the users.alias.new
+    # permission, and is enqueued with BRAZE_OPTIMAL_DELAY so Braze has propagated the new
+    # external_id before we attach the alias (an inline alias/new races identify and no-ops).
+    braze_tx.interface.add_basket_token_alias(external_id, external_id)
+
+
 # Braze errors: https://www.braze.com/docs/api/errors/
 class BrazeBadRequestError(Exception):
     pass  # 400 error (invalid request)
@@ -85,6 +94,7 @@ class BrazeEndpoint(Enum):
     USERS_DELETE = "/users/delete"
     SUBSCRIPTION_USER_STATUS = "/subscription/user/status"
     USERS_ADD_ALIAS = "/users/alias/new"
+    USERS_IDENTIFY = "/users/identify"
 
 
 class BrazeInterface:
@@ -337,6 +347,23 @@ class BrazeInterface:
         data = {"user_aliases": alias_operations}
         return self._request(BrazeEndpoint.USERS_ADD_ALIAS, data)
 
+    def identify_user(self, aliases_to_identify=None, emails_to_identify=None):
+        """
+        Assign an external_id to an alias-only user, merging the alias-only
+        profile into the identified profile.
+
+        @param aliases_to_identify: list of {"external_id", "user_alias": {"alias_name", "alias_label"}}
+        @param emails_to_identify: list of {"external_id", "email", "prioritization"}
+
+        https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/
+        """
+        data = {}
+        if aliases_to_identify:
+            data["aliases_to_identify"] = aliases_to_identify
+        if emails_to_identify:
+            data["emails_to_identify"] = emails_to_identify
+        return self._request(BrazeEndpoint.USERS_IDENTIFY, data)
+
 
 class Braze:
     """Basket interface to Braze"""
@@ -525,7 +552,7 @@ class Braze:
 
         basket_user_data = {
             "email": braze_user_data["email"],
-            "email_id": braze_user_data["external_id"],
+            "email_id": braze_user_data.get("external_id"),
             "id": braze_user_data["braze_id"],
             "first_name": braze_user_data.get("first_name"),
             "last_name": braze_user_data.get("last_name"),
@@ -536,7 +563,7 @@ class Braze:
             "last_modified_date": user_attributes.get("updated_at"),
             "optin": braze_user_data.get("email_subscribe") == "opted_in",
             "optout": braze_user_data.get("email_subscribe") == "unsubscribed",
-            "token": braze_user_data["external_id"],
+            "token": braze_user_data.get("external_id"),
             "ctms_legacy_token": user_attributes.get("basket_token"),
             "fxa_service": user_attributes.get("fxa_first_service"),
             "fxa_lang": user_attributes.get("fxa_lang"),

--- a/basket/news/schemas.py
+++ b/basket/news/schemas.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 
 from ninja import Field, Schema
-from pydantic import EmailStr
+from pydantic import EmailStr, field_validator
 
 
 class NewsletterSchema(Schema):
@@ -38,9 +38,16 @@ class RecoverUserSchema(Schema):
 class AssignExternalIdSchema(Schema):
     # Request body for the `/users/assign/` webhook. The caller (e.g. Braze, via
     # Liquid templating) supplies these fields. At least one is required (validated in the view).
-    email: str | None = None
+    email: EmailStr | None = None
     basket_token: str | None = None
     fxa_id: str | None = None
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def _blank_email_to_none(cls, value):
+        # Braze Liquid renders an empty string for absent attributes; treat that as "no email"
+        # so a basket_token/fxa_id-only call isn't rejected by EmailStr validation.
+        return value or None
 
 
 class NewslettersSchema(Schema):

--- a/basket/news/schemas.py
+++ b/basket/news/schemas.py
@@ -35,6 +35,14 @@ class RecoverUserSchema(Schema):
     email: EmailStr
 
 
+class AssignExternalIdSchema(Schema):
+    # Request body for the `/users/assign/` webhook. The caller (e.g. Braze, via
+    # Liquid templating) supplies these fields. At least one is required (validated in the view).
+    email: str | None = None
+    basket_token: str | None = None
+    fxa_id: str | None = None
+
+
 class NewslettersSchema(Schema):
     newsletters: dict[str, NewsletterSchema]
     status: str

--- a/basket/news/schemas.py
+++ b/basket/news/schemas.py
@@ -39,8 +39,8 @@ class AssignExternalIdSchema(Schema):
     # Request body for the `/users/assign/` webhook. The caller (e.g. Braze, via
     # Liquid templating) supplies these fields. At least one is required (validated in the view).
     email: EmailStr | None = None
-    basket_token: str | None = None
-    fxa_id: str | None = None
+    basket_token: str | None = Field(default=None, max_length=128)
+    fxa_id: str | None = Field(default=None, max_length=128)
 
     @field_validator("email", mode="before")
     @classmethod

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -624,6 +624,14 @@ NON_RETRYABLE_BRAZE_ERRORS = (
 )
 
 
+def _scrub_frame_locals(event, hint):
+    # Drop all stack-frame local variables from a Sentry event so PII in locals isn't sent.
+    for value in event.get("exception", {}).get("values", []):
+        for frame in (value.get("stacktrace") or {}).get("frames", []):
+            frame.pop("vars", None)
+    return event
+
+
 @rq_task
 def braze_assign_external_id(data):
     """
@@ -681,12 +689,13 @@ def braze_assign_external_id(data):
 
         metrics.incr("news.tasks.braze_assign_external_id", tags=["status:assigned"])
     except NON_RETRYABLE_BRAZE_ERRORS as exc:
-        # e.g. a missing Braze permission or malformed request: won't succeed on retry, so
-        # report to Sentry (project convention) + emit a metric instead of re-raising, which
-        # would fail the job and trigger RQ's retry storm. Sentry captures the frame locals
-        # (basket_token/fxa_id/email) for triage. Retryable errors (rate limit / 5xx /
-        # connection) are intentionally NOT caught here, so they still propagate and retry.
-        sentry_sdk.capture_exception(exc)
+        # Non-retryable (bad permission / malformed request): report + metric instead of
+        # re-raising, which would trigger RQ's retry storm. Retryable errors (rate limit /
+        # 5xx / connection) propagate and retry. Strip frame locals so the email/basket_token/
+        # fxa_id held there are never sent to Sentry.
+        with sentry_sdk.new_scope() as scope:
+            scope.add_event_processor(_scrub_frame_locals)
+            sentry_sdk.capture_exception(exc)
         metrics.incr("news.tasks.braze_assign_external_id", tags=["status:braze_client_error"])
 
 

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -4,6 +4,8 @@ from urllib.parse import urlencode
 from django.conf import settings
 from django.core.cache import cache
 
+import sentry_sdk
+
 from basket import metrics
 from basket.base.decorators import rq_task
 from basket.base.exceptions import BasketError
@@ -679,10 +681,12 @@ def braze_assign_external_id(data):
 
         metrics.incr("news.tasks.braze_assign_external_id", tags=["status:assigned"])
     except NON_RETRYABLE_BRAZE_ERRORS as exc:
-        # e.g. a missing Braze permission or malformed request. These won't succeed on retry,
-        # so log + emit a metric instead of failing the job and triggering RQ's retry storm.
-        # Retryable errors (rate limit / 5xx / connection) are intentionally NOT caught here.
-        log.error(f"braze_assign_external_id: non-retryable Braze error: {exc}")
+        # e.g. a missing Braze permission or malformed request: won't succeed on retry, so
+        # report to Sentry (project convention) + emit a metric instead of re-raising, which
+        # would fail the job and trigger RQ's retry storm. Sentry captures the frame locals
+        # (basket_token/fxa_id/email) for triage. Retryable errors (rate limit / 5xx /
+        # connection) are intentionally NOT caught here, so they still propagate and retry.
+        sentry_sdk.capture_exception(exc)
         metrics.incr("news.tasks.braze_assign_external_id", tags=["status:braze_client_error"])
 
 

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -7,10 +7,17 @@ from django.core.cache import cache
 from basket import metrics
 from basket.base.decorators import rq_task
 from basket.base.exceptions import BasketError
-from basket.base.utils import email_is_testing
+from basket.base.utils import email_is_testing, is_valid_uuid
 from basket.news.backends.braze import (
+    BRAZE_OPTIMAL_DELAY,
+    BrazeBadRequestError,
+    BrazeClientError,
+    BrazeForbiddenError,
+    BrazeNotFoundError,
+    BrazeUnauthorizedError,
     BrazeUserNotFoundByFxaIdError,
     BrazeUserNotFoundByTokenError,
+    assign_basket_token_alias_task,
     braze,
     braze_tx,
 )
@@ -601,6 +608,82 @@ def record_common_voice_update(data):
     else:
         new_data.update({"email": email, "token": generate_token()})
         ctms.add(new_data)
+
+
+# Braze client errors that won't succeed on retry (unlike rate-limit / 5xx / connection
+# errors, which the backend's own @retry handles). For these we log + metric rather than
+# letting the rq job fail and retry.
+NON_RETRYABLE_BRAZE_ERRORS = (
+    BrazeBadRequestError,
+    BrazeUnauthorizedError,
+    BrazeForbiddenError,
+    BrazeNotFoundError,
+    BrazeClientError,
+)
+
+
+@rq_task
+def braze_assign_external_id(data):
+    """
+    Assign an external_id to a Braze user that only has a user alias.
+
+    Triggered by an inbound webhook from Braze for a user lacking an external_id.
+    If the user already has an external_id, this is a no-op. Otherwise we pick an
+    external_id (the basket_token when it's a valid UUID, else a fresh one) and
+    write it back to Braze, keyed by whichever identifier Braze sent. Users who
+    arrived without a basket_token also get a basket_token alias whose value equals
+    the new external_id.
+    """
+    email = data.get("email")
+    basket_token = data.get("basket_token")
+    fxa_id = data.get("fxa_id")
+
+    try:
+        # If the user already has an external_id, there is nothing to do.
+        user = braze.get(email=email, token=basket_token, fxa_id=fxa_id)
+        if user and user.get("email_id"):
+            metrics.incr("news.tasks.braze_assign_external_id", tags=["status:already_assigned"])
+            return
+
+        # Prefer the basket_token as the external_id so that `external_id == basket_token`
+        # and basket's token lookups resolve. Otherwise mint a fresh one.
+        if basket_token and is_valid_uuid(basket_token):
+            external_id = basket_token
+        else:
+            external_id = generate_token()
+
+        # The identify write goes through `braze_tx` (BRAZE_API_KEY), which carries the
+        # `users.identify` permission; the read above uses `braze` (BRAZE_NEWSLETTER_API_KEY).
+        # basket_token and fxa_id are user aliases; email uses the email-identify form.
+        if basket_token:
+            user_alias = {"alias_name": basket_token, "alias_label": "basket_token"}
+        elif fxa_id:
+            user_alias = {"alias_name": fxa_id, "alias_label": "fxa_id"}
+        else:
+            user_alias = None
+
+        if user_alias:
+            braze_tx.interface.identify_user(aliases_to_identify=[{"external_id": external_id, "user_alias": user_alias}])
+        elif email:
+            braze_tx.interface.identify_user(
+                emails_to_identify=[{"external_id": external_id, "email": email, "prioritization": ["unidentified", "most_recently_updated"]}]
+            )
+
+        # Users who arrived without a basket_token (e.g. fxa_id-only) get one whose value IS
+        # the external_id, so they become a full basket user (external_id == basket_token) that
+        # basket's token lookups resolve. Users who came in with a basket_token already have it.
+        # Enqueued with a delay (not inline): Braze needs time to propagate the just-assigned
+        # external_id before alias/new can attach to it, otherwise it silently no-ops.
+        if not basket_token:
+            assign_basket_token_alias_task.delay(external_id, enqueue_in=BRAZE_OPTIMAL_DELAY)
+
+        metrics.incr("news.tasks.braze_assign_external_id", tags=["status:assigned"])
+    except NON_RETRYABLE_BRAZE_ERRORS as exc:
+        # e.g. a missing Braze permission or malformed request. These won't succeed on retry,
+        # so log + emit a metric instead of failing the job and triggering RQ's retry storm.
+        # Retryable errors (rate limit / 5xx / connection) are intentionally NOT caught here.
+        log.error(f"braze_assign_external_id: non-retryable Braze error: {exc}")
+        metrics.incr("news.tasks.braze_assign_external_id", tags=["status:braze_client_error"])
 
 
 def get_fxa_user_data(fxa_id, email, use_braze_backend=False):

--- a/basket/news/tests/api/test_auth.py
+++ b/basket/news/tests/api/test_auth.py
@@ -12,6 +12,7 @@ from basket.news.auth import (
     HeaderApiKey,
     QueryApiKey,
     Unauthorized,
+    WebhookBearerToken,
 )
 from basket.news.models import APIUser
 
@@ -128,3 +129,39 @@ class TestUnauthorized:
     def test_always_returns_unauthorized(self):
         request = self.request.get("/")
         assert Unauthorized()(request) == UNAUTHORIZED
+
+
+@pytest.mark.django_db
+class TestWebhookBearerToken:
+    def setup_method(self):
+        self.request = RequestFactory()
+
+    def test_valid_secret(self, settings):
+        settings.ASSIGN_WEBHOOK_SECRET = "webhook-secret"
+        request = self.request.post("/")
+        assert WebhookBearerToken().authenticate(request, "webhook-secret") == AUTHORIZED
+
+    def test_invalid_secret(self, settings):
+        settings.ASSIGN_WEBHOOK_SECRET = "webhook-secret"
+        request = self.request.post("/")
+        assert WebhookBearerToken().authenticate(request, "nope") is None
+
+    def test_unset_secret_rejects_all(self, settings):
+        # An empty/unset secret must never authenticate (even with an empty token).
+        settings.ASSIGN_WEBHOOK_SECRET = ""
+        request = self.request.post("/")
+        assert WebhookBearerToken().authenticate(request, "") is None
+        assert WebhookBearerToken().authenticate(request, "anything") is None
+
+    def test_scope_secret_rejected_by_apiuser_auth(self, settings):
+        # The webhook secret must NOT authenticate APIUser-based endpoints.
+        settings.ASSIGN_WEBHOOK_SECRET = "webhook-secret"
+        request = self.request.get("/", HTTP_X_API_KEY="webhook-secret")
+        assert HeaderApiKey().authenticate(request, "webhook-secret") is None
+
+    def test_scope_apiuser_key_rejected_by_webhook_auth(self, settings):
+        # An APIUser key must NOT authenticate the webhook endpoint.
+        settings.ASSIGN_WEBHOOK_SECRET = "webhook-secret"
+        APIUser.objects.create(api_key="apiuser-key")
+        request = self.request.post("/")
+        assert WebhookBearerToken().authenticate(request, "apiuser-key") is None

--- a/basket/news/tests/api/test_users_assign.py
+++ b/basket/news/tests/api/test_users_assign.py
@@ -114,6 +114,17 @@ class TestUsersAssignAPI(_TestAPIBase):
             assert resp.status_code == 422
             mock_task.assert_not_called()
 
+    def test_overlong_identifier_is_rejected(self):
+        with patch("basket.news.tasks.braze_assign_external_id.delay", autospec=True) as mock_task:
+            resp = self.client.post(
+                self.url,
+                {"basket_token": "a" * 129},
+                content_type="application/json",
+                headers=self.auth,
+            )
+            assert resp.status_code == 422
+            mock_task.assert_not_called()
+
     def test_throttled_per_identifier(self):
         # The default rate is "4/5m", so repeated calls for the SAME identifier are throttled.
         cache.clear()

--- a/basket/news/tests/api/test_users_assign.py
+++ b/basket/news/tests/api/test_users_assign.py
@@ -87,6 +87,33 @@ class TestUsersAssignAPI(_TestAPIBase):
             assert data["code"] == errors.BASKET_USAGE_ERROR
             mock_task.assert_not_called()
 
+    def test_blank_email_with_token_is_accepted(self, settings):
+        # Braze Liquid may send an empty email alongside a real identifier; the blank email
+        # is coerced to None (not rejected by EmailStr) and the token is used.
+        settings.BRAZE_ONLY_WRITE_ENABLE = True
+        token = str(uuid.uuid4())
+        with patch("basket.news.tasks.braze_assign_external_id.delay", autospec=True) as mock_task:
+            resp = self.client.post(
+                self.url,
+                {"email": "", "basket_token": token},
+                content_type="application/json",
+                headers=self.auth,
+            )
+            assert resp.status_code == 200, resp.content
+            mock_task.assert_called_once_with({"email": None, "basket_token": token, "fxa_id": None})
+
+    def test_invalid_email_is_rejected(self):
+        # A non-empty malformed email fails EmailStr validation at the boundary (422).
+        with patch("basket.news.tasks.braze_assign_external_id.delay", autospec=True) as mock_task:
+            resp = self.client.post(
+                self.url,
+                {"email": "not-an-email"},
+                content_type="application/json",
+                headers=self.auth,
+            )
+            assert resp.status_code == 422
+            mock_task.assert_not_called()
+
     def test_throttled_per_identifier(self):
         # The default rate is "4/5m", so repeated calls for the SAME identifier are throttled.
         cache.clear()

--- a/basket/news/tests/api/test_users_assign.py
+++ b/basket/news/tests/api/test_users_assign.py
@@ -1,0 +1,105 @@
+import uuid
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.urls import reverse
+
+import pytest
+
+from basket import errors
+from basket.news.schemas import ErrorSchema, OkSchema
+from basket.news.tests.api import _TestAPIBase
+
+WEBHOOK_SECRET = "webhook-secret"
+
+
+@pytest.mark.django_db
+class TestUsersAssignAPI(_TestAPIBase):
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.url = reverse("api.v1:users.assign")
+        self.test_maintenance_mode = False  # endpoint does not gate on maintenance mode
+        self.auth = {"Authorization": f"Bearer {WEBHOOK_SECRET}"}
+
+    @pytest.fixture(autouse=True)
+    def _set_secret(self, settings):
+        settings.ASSIGN_WEBHOOK_SECRET = WEBHOOK_SECRET
+
+    def valid_request(self):
+        return self.client.post(
+            self.url,
+            {"basket_token": str(uuid.uuid4())},
+            content_type="application/json",
+            headers=self.auth,
+        )
+
+    def test_valid_request_enqueues_braze_task(self, settings):
+        settings.BRAZE_ONLY_WRITE_ENABLE = True
+        token = str(uuid.uuid4())
+        with patch("basket.news.tasks.braze_assign_external_id.delay", autospec=True) as mock_task:
+            resp = self.client.post(
+                self.url,
+                {"basket_token": token},
+                content_type="application/json",
+                headers=self.auth,
+            )
+            assert resp.status_code == 200, resp.content
+            self.validate_schema(resp.json(), OkSchema)
+            mock_task.assert_called_once_with({"email": None, "basket_token": token, "fxa_id": None})
+
+    def test_noop_when_braze_not_write_backend(self, settings):
+        # Backend-gated: with no Braze write flag set, nothing is dispatched but the call succeeds.
+        settings.BRAZE_PARALLEL_WRITE_ENABLE = False
+        settings.BRAZE_ONLY_WRITE_ENABLE = False
+        with patch("basket.news.tasks.braze_assign_external_id.delay", autospec=True) as mock_task:
+            resp = self.valid_request()
+            assert resp.status_code == 200, resp.content
+            self.validate_schema(resp.json(), OkSchema)
+            mock_task.assert_not_called()
+
+    def test_missing_auth_is_401(self):
+        with patch("basket.news.tasks.braze_assign_external_id.delay", autospec=True) as mock_task:
+            resp = self.client.post(
+                self.url,
+                {"basket_token": str(uuid.uuid4())},
+                content_type="application/json",
+            )
+            assert resp.status_code == 401
+            mock_task.assert_not_called()
+
+    def test_bad_key_is_401(self):
+        with patch("basket.news.tasks.braze_assign_external_id.delay", autospec=True) as mock_task:
+            resp = self.client.post(
+                self.url,
+                {"basket_token": str(uuid.uuid4())},
+                content_type="application/json",
+                headers={"Authorization": "Bearer nope"},
+            )
+            assert resp.status_code == 401
+            mock_task.assert_not_called()
+
+    def test_no_identifier_is_400(self):
+        with patch("basket.news.tasks.braze_assign_external_id.delay", autospec=True) as mock_task:
+            resp = self.client.post(self.url, {}, content_type="application/json", headers=self.auth)
+            assert resp.status_code == 400
+            data = resp.json()
+            self.validate_schema(data, ErrorSchema)
+            assert data["code"] == errors.BASKET_USAGE_ERROR
+            mock_task.assert_not_called()
+
+    def test_throttled_per_identifier(self):
+        # The default rate is "4/5m", so repeated calls for the SAME identifier are throttled.
+        cache.clear()
+        token = str(uuid.uuid4())
+        with patch("basket.news.tasks.braze_assign_external_id.delay", autospec=True):
+            codes = [
+                self.client.post(
+                    self.url,
+                    {"basket_token": token},
+                    content_type="application/json",
+                    headers=self.auth,
+                ).status_code
+                for _ in range(6)
+            ]
+        assert 429 in codes
+        cache.clear()

--- a/basket/news/tests/test_braze.py
+++ b/basket/news/tests/test_braze.py
@@ -395,9 +395,9 @@ def test_from_vendor(braze_client):
     assert braze_instance.from_vendor(mock_braze_user_data, mock_braze_user_subscription_groups) == mock_basket_user_data
 
 
-def test_from_vendor_alias_only_user_has_no_external_id(braze_client):
-    # Alias-only users (awaiting external_id assignment) have no `external_id` key.
-    # from_vendor must yield None for email_id/token rather than raising KeyError.
+def test_from_vendor_alias_only_user_returns_none(braze_client):
+    # An alias-only profile (no external_id) isn't a Basket user yet; from_vendor returns
+    # None rather than a dict with token=None (which would break callers/response schemas).
     braze_instance = Braze(braze_client)
     alias_only_user = {
         "email": "alias-only@example.com",
@@ -405,11 +405,7 @@ def test_from_vendor_alias_only_user_has_no_external_id(braze_client):
         "user_aliases": [{"alias_name": "the-fxa-id", "alias_label": "fxa_id"}],
     }
 
-    result = braze_instance.from_vendor(alias_only_user, [])
-
-    assert result["email_id"] is None
-    assert result["token"] is None
-    assert result["fxa_id"] == "the-fxa-id"
+    assert braze_instance.from_vendor(alias_only_user, []) is None
 
 
 @mock.patch(
@@ -693,6 +689,18 @@ def test_braze_get_export_missing_email(mock_newsletters, braze_client):
         m.register_uri("POST", "http://test.com/users/export/ids", json={"users": [mock_braze_user_data_without_email]})
 
         assert braze_instance.get(email=email) is None
+
+
+def test_braze_get_alias_only_user_returns_none(braze_client):
+    # A profile found by email/alias but with no external_id is alias-only (awaiting
+    # /users/assign) — braze.get treats it as not found.
+    braze_instance = Braze(braze_client)
+    alias_only = mock_braze_user_data.copy()
+    del alias_only["external_id"]
+
+    with requests_mock.mock() as m:
+        m.register_uri("POST", "http://test.com/users/export/ids", json={"users": [alias_only]})
+        assert braze_instance.get(email=alias_only["email"]) is None
 
 
 def test_braze_get_opted_out_user(braze_client):

--- a/basket/news/tests/test_braze.py
+++ b/basket/news/tests/test_braze.py
@@ -231,6 +231,37 @@ def test_braze_add_basket_token_alias(braze_client):
         assert m.last_request.json() == expected
 
 
+def test_braze_identify_user_by_alias(braze_client):
+    aliases = [{"external_id": "abc", "user_alias": {"alias_name": "tok", "alias_label": "basket_token"}}]
+    expected = {"aliases_to_identify": aliases}
+
+    with requests_mock.mock() as m:
+        m.register_uri("POST", "http://test.com/users/identify", json={})
+        braze_client.identify_user(aliases_to_identify=aliases)
+        assert m.last_request.json() == expected
+
+
+def test_braze_identify_user_by_email(braze_client):
+    emails = [{"external_id": "abc", "email": "test@test.com", "prioritization": ["unidentified"]}]
+    expected = {"emails_to_identify": emails}
+
+    with requests_mock.mock() as m:
+        m.register_uri("POST", "http://test.com/users/identify", json={})
+        braze_client.identify_user(emails_to_identify=emails)
+        assert m.last_request.json() == expected
+
+
+def test_braze_identify_endpoint_value():
+    assert braze.BrazeEndpoint.USERS_IDENTIFY.value == "/users/identify"
+
+
+@mock.patch("basket.news.backends.braze.braze_tx")
+def test_assign_basket_token_alias_task(mock_braze_tx):
+    # Sets a basket_token alias whose value == external_id, via braze_tx (BRAZE_API_KEY).
+    braze.assign_basket_token_alias_task("ext-123")
+    mock_braze_tx.interface.add_basket_token_alias.assert_called_once_with("ext-123", "ext-123")
+
+
 def test_braze_exception_400(braze_client):
     with requests_mock.mock() as m:
         m.register_uri("POST", "http://test.com/users/track", status_code=400, json={})
@@ -362,6 +393,23 @@ def test_from_vendor(braze_client):
     braze_instance = Braze(braze_client)
 
     assert braze_instance.from_vendor(mock_braze_user_data, mock_braze_user_subscription_groups) == mock_basket_user_data
+
+
+def test_from_vendor_alias_only_user_has_no_external_id(braze_client):
+    # Alias-only users (awaiting external_id assignment) have no `external_id` key.
+    # from_vendor must yield None for email_id/token rather than raising KeyError.
+    braze_instance = Braze(braze_client)
+    alias_only_user = {
+        "email": "alias-only@example.com",
+        "braze_id": "braze-123",
+        "user_aliases": [{"alias_name": "the-fxa-id", "alias_label": "fxa_id"}],
+    }
+
+    result = braze_instance.from_vendor(alias_only_user, [])
+
+    assert result["email_id"] is None
+    assert result["token"] is None
+    assert result["fxa_id"] == "the-fxa-id"
 
 
 @mock.patch(

--- a/basket/news/tests/test_braze.py
+++ b/basket/news/tests/test_braze.py
@@ -251,6 +251,12 @@ def test_braze_identify_user_by_email(braze_client):
         assert m.last_request.json() == expected
 
 
+def test_braze_identify_user_requires_an_identifier(braze_client):
+    # An empty payload would 400 at Braze; identify_user fails fast instead.
+    with pytest.raises(ValueError):
+        braze_client.identify_user()
+
+
 def test_braze_identify_endpoint_value():
     assert braze.BrazeEndpoint.USERS_IDENTIFY.value == "/users/identify"
 

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -6,10 +6,12 @@ from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from basket.news.backends.braze import BRAZE_OPTIMAL_DELAY
 from basket.news.backends.ctms import CTMSNotFoundByAltIDError
 from basket.news.models import BrazeTxEmailMessage, FailedTask
 from basket.news.tasks import (
     SUBSCRIBE,
+    braze_assign_external_id,
     fxa_delete,
     fxa_email_changed,
     fxa_login,
@@ -748,3 +750,128 @@ class TestUpsertContact(TestCase):
                 "token": "ABC123",
             }
         )
+
+
+@patch("basket.news.tasks.braze_tx")
+@patch("basket.news.tasks.braze")
+class BrazeAssignExternalIdTests(TestCase):
+    # The read (`braze.get`) uses the newsletter key; the identify write uses `braze_tx`
+    # (BRAZE_API_KEY), which carries the `users.identify` permission.
+    def test_already_assigned_is_noop(self, mock_braze, mock_braze_tx):
+        # User already has an external_id (email_id) -> nothing to do.
+        mock_braze.get.return_value = {"email": "a@b.com", "email_id": "existing-id"}
+        braze_assign_external_id({"basket_token": str(uuid4())})
+        mock_braze_tx.interface.identify_user.assert_not_called()
+        mock_braze_tx.interface.add_basket_token_alias.assert_not_called()
+
+    def test_basket_token_becomes_external_id(self, mock_braze, mock_braze_tx):
+        mock_braze.get.return_value = None
+        token = str(uuid4())
+        braze_assign_external_id({"basket_token": token})
+        mock_braze_tx.interface.identify_user.assert_called_once_with(
+            aliases_to_identify=[
+                {
+                    "external_id": token,
+                    "user_alias": {"alias_name": token, "alias_label": "basket_token"},
+                }
+            ]
+        )
+        # User arrived with a basket_token, so we don't add another alias.
+        mock_braze_tx.interface.add_basket_token_alias.assert_not_called()
+
+    def test_invalid_token_mints_fresh_external_id(self, mock_braze, mock_braze_tx):
+        mock_braze.get.return_value = None
+        braze_assign_external_id({"basket_token": "not-a-uuid"})
+        kwargs = mock_braze_tx.interface.identify_user.call_args.kwargs
+        alias = kwargs["aliases_to_identify"][0]
+        assert alias["user_alias"] == {"alias_name": "not-a-uuid", "alias_label": "basket_token"}
+        # external_id is a freshly minted UUID, not the invalid token.
+        assert alias["external_id"] != "not-a-uuid"
+        # A basket_token (even if junk) was supplied, so no new alias is added.
+        mock_braze_tx.interface.add_basket_token_alias.assert_not_called()
+
+    @patch("basket.news.tasks.assign_basket_token_alias_task")
+    def test_fxa_id_only_assigns_and_enqueues_basket_token(self, mock_assign_task, mock_braze, mock_braze_tx):
+        mock_braze.get.return_value = None
+        braze_assign_external_id({"fxa_id": "fxa-123"})
+        kwargs = mock_braze_tx.interface.identify_user.call_args.kwargs
+        alias = kwargs["aliases_to_identify"][0]
+        external_id = alias["external_id"]
+        assert alias["user_alias"] == {"alias_name": "fxa-123", "alias_label": "fxa_id"}
+        assert external_id
+        # fxa-only user gets a basket_token alias == external_id, enqueued with a delay
+        # (not written inline) so Braze can propagate the external_id first.
+        mock_assign_task.delay.assert_called_once_with(external_id, enqueue_in=BRAZE_OPTIMAL_DELAY)
+        mock_braze_tx.interface.add_basket_token_alias.assert_not_called()
+
+    @patch("basket.news.tasks.assign_basket_token_alias_task")
+    def test_email_only_assigns_and_enqueues_basket_token(self, mock_assign_task, mock_braze, mock_braze_tx):
+        mock_braze.get.return_value = None
+        braze_assign_external_id({"email": "a@b.com"})
+        kwargs = mock_braze_tx.interface.identify_user.call_args.kwargs
+        entry = kwargs["emails_to_identify"][0]
+        external_id = entry["external_id"]
+        assert entry["email"] == "a@b.com"
+        assert external_id
+        mock_assign_task.delay.assert_called_once_with(external_id, enqueue_in=BRAZE_OPTIMAL_DELAY)
+        mock_braze_tx.interface.add_basket_token_alias.assert_not_called()
+
+    def test_basket_token_wins_when_all_identifiers_present(self, mock_braze, mock_braze_tx):
+        # Precedence guard: basket_token > fxa_id > email.
+        mock_braze.get.return_value = None
+        token = str(uuid4())
+        braze_assign_external_id({"basket_token": token, "fxa_id": "fxa-123", "email": "a@b.com"})
+        mock_braze_tx.interface.identify_user.assert_called_once_with(
+            aliases_to_identify=[
+                {
+                    "external_id": token,
+                    "user_alias": {"alias_name": token, "alias_label": "basket_token"},
+                }
+            ]
+        )
+        mock_braze_tx.interface.add_basket_token_alias.assert_not_called()
+
+    @patch("basket.news.tasks.assign_basket_token_alias_task")
+    def test_fxa_id_wins_over_email(self, mock_assign_task, mock_braze, mock_braze_tx):
+        # With fxa_id and email but no basket_token, identify by the fxa_id alias (not email).
+        mock_braze.get.return_value = None
+        braze_assign_external_id({"fxa_id": "fxa-123", "email": "a@b.com"})
+        kwargs = mock_braze_tx.interface.identify_user.call_args.kwargs
+        assert "aliases_to_identify" in kwargs  # alias form, not emails_to_identify
+        assert kwargs["aliases_to_identify"][0]["user_alias"] == {"alias_name": "fxa-123", "alias_label": "fxa_id"}
+
+    def test_already_assigned_when_found_by_fxa_id(self, mock_braze, mock_braze_tx):
+        # Re-trigger for an already-identified user found via fxa_id is a no-op (idempotent).
+        mock_braze.get.return_value = {"email": "a@b.com", "email_id": "existing-id"}
+        braze_assign_external_id({"fxa_id": "fxa-123"})
+        mock_braze_tx.interface.identify_user.assert_not_called()
+        mock_braze_tx.interface.add_basket_token_alias.assert_not_called()
+
+    def test_already_assigned_when_found_by_email(self, mock_braze, mock_braze_tx):
+        mock_braze.get.return_value = {"email": "a@b.com", "email_id": "existing-id"}
+        braze_assign_external_id({"email": "a@b.com"})
+        mock_braze_tx.interface.identify_user.assert_not_called()
+        mock_braze_tx.interface.add_basket_token_alias.assert_not_called()
+
+    @patch("basket.news.tasks.metrics")
+    def test_non_retryable_braze_error_is_caught(self, mock_metrics, mock_braze, mock_braze_tx):
+        # A non-retryable Braze client error (e.g. 403 missing permission) must NOT propagate
+        # (which would fail the job and trigger RQ retries); it's logged + metriced instead.
+        from basket.news.backends.braze import BrazeForbiddenError
+
+        mock_braze.get.return_value = None
+        mock_braze_tx.interface.identify_user.side_effect = BrazeForbiddenError("Access Denied")
+
+        braze_assign_external_id({"fxa_id": "fxa-123"})  # should not raise
+
+        mock_metrics.incr.assert_called_with("news.tasks.braze_assign_external_id", tags=["status:braze_client_error"])
+
+    def test_retryable_braze_error_still_propagates(self, mock_braze, mock_braze_tx):
+        # Transient errors must still bubble up so RQ/tenacity can retry.
+        from basket.news.backends.braze import BrazeRateLimitError
+
+        mock_braze.get.return_value = None
+        mock_braze_tx.interface.identify_user.side_effect = BrazeRateLimitError("slow down")
+
+        with self.assertRaises(BrazeRateLimitError):
+            braze_assign_external_id({"fxa_id": "fxa-123"})

--- a/basket/news/tests/test_tasks.py
+++ b/basket/news/tests/test_tasks.py
@@ -853,17 +853,20 @@ class BrazeAssignExternalIdTests(TestCase):
         mock_braze_tx.interface.identify_user.assert_not_called()
         mock_braze_tx.interface.add_basket_token_alias.assert_not_called()
 
+    @patch("basket.news.tasks.sentry_sdk")
     @patch("basket.news.tasks.metrics")
-    def test_non_retryable_braze_error_is_caught(self, mock_metrics, mock_braze, mock_braze_tx):
+    def test_non_retryable_braze_error_is_caught(self, mock_metrics, mock_sentry, mock_braze, mock_braze_tx):
         # A non-retryable Braze client error (e.g. 403 missing permission) must NOT propagate
-        # (which would fail the job and trigger RQ retries); it's logged + metriced instead.
+        # (which would fail the job and trigger RQ retries); it's reported to Sentry + metriced.
         from basket.news.backends.braze import BrazeForbiddenError
 
         mock_braze.get.return_value = None
-        mock_braze_tx.interface.identify_user.side_effect = BrazeForbiddenError("Access Denied")
+        exc = BrazeForbiddenError("Access Denied")
+        mock_braze_tx.interface.identify_user.side_effect = exc
 
         braze_assign_external_id({"fxa_id": "fxa-123"})  # should not raise
 
+        mock_sentry.capture_exception.assert_called_once_with(exc)
         mock_metrics.incr.assert_called_with("news.tasks.braze_assign_external_id", tags=["status:braze_client_error"])
 
     def test_retryable_braze_error_still_propagates(self, mock_braze, mock_braze_tx):

--- a/basket/settings.py
+++ b/basket/settings.py
@@ -253,6 +253,8 @@ EMAIL_SUBSCRIBE_RATE_LIMIT = config("EMAIL_SUBSCRIBE_RATE_LIMIT", default="4/5m"
 # Inbound `/users/assign/` webhook: shared bearer secret + per-identifier rate limit.
 ASSIGN_WEBHOOK_SECRET = config("ASSIGN_WEBHOOK_SECRET", default="")
 ASSIGN_RATE_LIMIT = config("ASSIGN_RATE_LIMIT", default="4/5m")
+# Endpoint-wide backstop; size to total expected Braze volume. Tune via env.
+ASSIGN_GLOBAL_RATE_LIMIT = config("ASSIGN_GLOBAL_RATE_LIMIT", default="1000/m")
 CONTACT_ENTERPRISE_RATE_LIMIT = config("CONTACT_ENTERPRISE_RATE_LIMIT", default="5/h")
 ENTERPRISE_CONTACT_SINK = config("ENTERPRISE_CONTACT_SINK", default="google_sheets")
 GOOGLE_SHEETS_CONTACT_SPREADSHEET_ID = config("GOOGLE_SHEETS_CONTACT_SPREADSHEET_ID", default="")

--- a/basket/settings.py
+++ b/basket/settings.py
@@ -250,6 +250,9 @@ CORS_URLS_REGEX = r"^/(api/|news/|subscribe)"
 # view rate limiting
 RATELIMIT_VIEW = "basket.news.views.ratelimited"
 EMAIL_SUBSCRIBE_RATE_LIMIT = config("EMAIL_SUBSCRIBE_RATE_LIMIT", default="4/5m")
+# Inbound `/users/assign/` webhook: shared bearer secret + per-identifier rate limit.
+ASSIGN_WEBHOOK_SECRET = config("ASSIGN_WEBHOOK_SECRET", default="")
+ASSIGN_RATE_LIMIT = config("ASSIGN_RATE_LIMIT", default="4/5m")
 CONTACT_ENTERPRISE_RATE_LIMIT = config("CONTACT_ENTERPRISE_RATE_LIMIT", default="5/h")
 ENTERPRISE_CONTACT_SINK = config("ENTERPRISE_CONTACT_SINK", default="google_sheets")
 GOOGLE_SHEETS_CONTACT_SPREADSHEET_ID = config("GOOGLE_SHEETS_CONTACT_SPREADSHEET_ID", default="")


### PR DESCRIPTION
Adds `POST /api/v1/users/assign/`, an authenticated webhook (bearer secret) that Braze calls for users who have only a user alias and no external_id. Basket assigns one reusing the basket_token when it's a valid UUID, otherwise minting a fresh UUID and writes it back via Braze /users/identify. fxa-only/email-only users also get a basket_token alias equal to their external_id, added via a delayed task so Braze can propagate the new id first. Backend-gated by the BRAZE_*_WRITE flags; non-retryable Braze errors are logged + metriced instead of failing the job. (WT-1280)